### PR TITLE
Feature/should have resource not found error

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.csproj
+++ b/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="AndcultureCode.CSharp.Conductors" Version="1.0.0" />
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
-    <PackageReference Include="AndcultureCode.CSharp.Extensions" Version="0.0.8" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.4.7" />
+    <PackageReference Include="AndcultureCode.CSharp.Extensions" Version="0.4.2" />
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Bogus" Version="28.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />

--- a/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
+++ b/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
@@ -42,6 +42,7 @@
   - [ShouldHaveErrors(result,exactCount)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldHaveErrors-AndcultureCode-CSharp-Core-Interfaces-IResult{System-Boolean},System-Nullable{System-Int32}- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldHaveErrors(AndcultureCode.CSharp.Core.Interfaces.IResult{System.Boolean},System.Nullable{System.Int32})')
   - [ShouldHaveErrorsFor\`\`1(result,property,exactCount,containedInMessage)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldHaveErrorsFor``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0},System-String,System-Nullable{System-Int32},System-String- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldHaveErrorsFor``1(AndcultureCode.CSharp.Core.Interfaces.IResult{``0},System.String,System.Nullable{System.Int32},System.String)')
   - [ShouldHaveErrors\`\`1(result,exactCount)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldHaveErrors``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0},System-Nullable{System-Int32}- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldHaveErrors``1(AndcultureCode.CSharp.Core.Interfaces.IResult{``0},System.Nullable{System.Int32})')
+  - [ShouldHaveResourceNotFoundError\`\`1(result)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldHaveResourceNotFoundError``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0}- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldHaveResourceNotFoundError``1(AndcultureCode.CSharp.Core.Interfaces.IResult{``0})')
   - [ShouldNotHaveErrorsFor\`\`1(result,property)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldNotHaveErrorsFor``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0},System-String- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldNotHaveErrorsFor``1(AndcultureCode.CSharp.Core.Interfaces.IResult{``0},System.String)')
   - [ShouldNotHaveErrors\`\`1(result)](#M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldNotHaveErrors``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0}- 'AndcultureCode.CSharp.Testing.Extensions.IResultMatcherExtensions.ShouldNotHaveErrors``1(AndcultureCode.CSharp.Core.Interfaces.IResult{``0})')
 
@@ -610,6 +611,25 @@ Assert that the result has at least one error
 | ---- | ---- | ----------- |
 | result | [AndcultureCode.CSharp.Core.Interfaces.IResult{\`\`0}](#T-AndcultureCode-CSharp-Core-Interfaces-IResult{``0} 'AndcultureCode.CSharp.Core.Interfaces.IResult{``0}') | Result under test |
 | exactCount | [System.Nullable{System.Int32}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Nullable 'System.Nullable{System.Int32}') | When supplied, asserts the result has this exact number of errors |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T |  |
+
+<a name='M-AndcultureCode-CSharp-Testing-Extensions-IResultMatcherExtensions-ShouldHaveResourceNotFoundError``1-AndcultureCode-CSharp-Core-Interfaces-IResult{``0}-'></a>
+### ShouldHaveResourceNotFoundError\`\`1(result) `method`
+
+##### Summary
+
+Assert error exists for \`ERROR_RESOURCE_NOT_FOUND_KEY\`
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| result | [AndcultureCode.CSharp.Core.Interfaces.IResult{\`\`0}](#T-AndcultureCode-CSharp-Core-Interfaces-IResult{``0} 'AndcultureCode.CSharp.Core.Interfaces.IResult{``0}') | Result under test |
 
 ##### Generic Types
 

--- a/src/AndcultureCode.CSharp.Testing/Extensions/Matchers/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/Matchers/IResultMatcherExtensions.cs
@@ -3,6 +3,7 @@ using AndcultureCode.CSharp.Core.Extensions;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Testing.Constants;
 using Shouldly;
+using CoreErrorConstants = AndcultureCode.CSharp.Core.Constants.ErrorConstants;
 
 namespace AndcultureCode.CSharp.Testing.Extensions
 {
@@ -99,6 +100,14 @@ namespace AndcultureCode.CSharp.Testing.Extensions
                 result.Errors.Where(e => e.Key == property).Count().ShouldBe((int)exactCount);
             }
         }
+
+        /// <summary>
+        /// Assert error exists for `ERROR_RESOURCE_NOT_FOUND_KEY`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <typeparam name="T"></typeparam>
+        public static void ShouldHaveResourceNotFoundError<T>(this IResult<T> result) =>
+            result.ShouldHaveErrorsFor(CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY);
 
         /// <summary>
         /// Assert that there are no errors for the given result

--- a/test/AndcultureCode.CSharp.Testing.Tests/AndcultureCode.CSharp.Testing.Tests.csproj
+++ b/test/AndcultureCode.CSharp.Testing.Tests/AndcultureCode.CSharp.Testing.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.1.1" />
+    <PackageReference Include="AndcultureCode.CSharp.Core" Version="0.4.7" />
     <PackageReference Include="coverlet.msbuild" Version="2.6.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/AndcultureCode.CSharp.Testing.Tests/Factories/ErrorFactory.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Factories/ErrorFactory.cs
@@ -1,5 +1,6 @@
 using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Testing.Constants;
+using CoreErrorConstants = AndcultureCode.CSharp.Core.Constants.ErrorConstants;
 
 namespace AndcultureCode.CSharp.Testing.Factories
 {
@@ -8,6 +9,7 @@ namespace AndcultureCode.CSharp.Testing.Factories
         #region Constants
 
         public const string BASIC_ERROR = "BASIC_ERROR";
+        public const string RESOURCE_NOT_FOUND_ERROR = CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY;
 
         #endregion Constants
 
@@ -23,6 +25,12 @@ namespace AndcultureCode.CSharp.Testing.Factories
             {
                 Key = ErrorConstants.BASIC_ERROR_KEY,
                 Message = ErrorConstants.BASIC_ERROR_MESSAGE
+            });
+
+            this.DefineFactory(RESOURCE_NOT_FOUND_ERROR, () => new Error
+            {
+                Key = CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY,
+                Message = Random.Words()
             });
         }
     }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -279,5 +279,72 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldHaveErrorsFor
+
+        #region ShouldHaveResourceNotFoundError
+
+        [Fact]
+        public void ShouldHaveResourceNotFoundError_When_Errors_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<object>((e) => e.Errors = null);
+
+            // Act
+            var ex = Record.Exception(() =>
+            {
+                result.ShouldHaveResourceNotFoundError();
+            });
+
+            // Assert
+            ex.ShouldNotBeNull();
+            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldHaveResourceNotFoundError_When_Errors_Empty_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<object>((e) => e.Errors = new List<IError>());
+
+            // Act & Assert
+            Should.Throw<Exception>(() =>
+            {
+                result.ShouldHaveResourceNotFoundError();
+            });
+        }
+
+        [Fact]
+        public void ShouldHaveResourceNotFoundError_When_Errors_Contains_Other_Keys_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<object>((e) => e.Errors = new List<IError>
+            {
+                Build<Error>()
+            });
+
+            // Act & Assert
+            Should.Throw<Exception>(() =>
+            {
+                result.ShouldHaveResourceNotFoundError();
+            });
+        }
+
+        [Fact]
+        public void ShouldHaveResourceNotFoundError_When_Errors_Contains_ResourceNotFoundKey_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<object>((e) => e.Errors = new List<IError>
+            {
+                Build<Error>(ErrorFactory.RESOURCE_NOT_FOUND_ERROR)
+            });
+
+            // Act & Assert
+            Should.NotThrow(() =>
+            {
+                result.ShouldHaveResourceNotFoundError();
+            });
+        }
+
+
+        #endregion ShouldHaveResourceNotFoundError
     }
 }


### PR DESCRIPTION
Fixes AndcultureCode/AndcultureCode.DotnetReact.Boilerplate#22

Adds a new `IResult<T>` matcher for asserting an error is found for `ERROR_RESOURCE_NOT_FOUND_KEY`, a common error key when returning `NotFound` from a controller in the context of a web application.

Also updated `AndcultureCode.CSharp.Extensions` dep to 0.4.2, as the build was giving a package downgrade warning leaving it at 0.0.8. We should be keeping these relatively up-to-date anyway.

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [ ] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
