### PR TITLE
Feature/add faker instance to base test

### DIFF
--- a/.vscode/csharp.code-snippets
+++ b/.vscode/csharp.code-snippets
@@ -1,0 +1,13 @@
+{
+    // Place your snippets for csharp here. Each snippet is defined under a snippet name and has a prefix, body and
+    // description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+    // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. Placeholders with the
+    // same ids are connected.
+    // Snippets can be easily generated or modified using https://snippet-generator.app/
+
+    "C# Region": {
+        "prefix": "cs-region",
+        "body": ["#region $1", "", "#endregion $1"],
+        "description": "C# region"
+    }
+}

--- a/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
+++ b/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
@@ -8,6 +8,8 @@
   - [GetRepositoryConductorDeps\`\`1(repository)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-GetRepositoryConductorDeps``1-AndcultureCode-CSharp-Core-Interfaces-Data-IRepository{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.GetRepositoryConductorDeps``1(AndcultureCode.CSharp.Core.Interfaces.Data.IRepository{``0})')
 - [BaseTest](#T-AndcultureCode-CSharp-Testing-Tests-BaseTest 'AndcultureCode.CSharp.Testing.Tests.BaseTest')
   - [#ctor(output)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#ctor-Xunit-Abstractions-ITestOutputHelper- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.#ctor(Xunit.Abstractions.ITestOutputHelper)')
+  - [Faker](#P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Faker 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Faker')
+  - [Random](#P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Random 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Random')
   - [#cctor()](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#cctor 'AndcultureCode.CSharp.Testing.Tests.BaseTest.#cctor')
   - [BuildResult\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildResult``1-System-Action{AndcultureCode-CSharp-Core-Models-Result{``0}}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.BuildResult``1(System.Action{AndcultureCode.CSharp.Core.Models.Result{``0}}[])')
 - [Factory](#T-AndcultureCode-CSharp-Testing-Factories-Factory 'AndcultureCode.CSharp.Testing.Factories.Factory')
@@ -134,6 +136,26 @@ Instance constructor to set up common test-level actors
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | output | [Xunit.Abstractions.ITestOutputHelper](#T-Xunit-Abstractions-ITestOutputHelper 'Xunit.Abstractions.ITestOutputHelper') |  |
+
+<a name='P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Faker'></a>
+### Faker `property`
+
+##### Summary
+
+Cached instance of 'Faker' to use for specific data generation functions not available
+from Randomizer (such as email addresses, ip addresses, names, etc.)
+
+##### Returns
+
+
+
+<a name='P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Random'></a>
+### Random `property`
+
+##### Summary
+
+Wrapper property for accessing the 'Randomizer' instance of 'Faker' directly. This field
+will instantiate a new Faker instance if it has not yet been accessed directly.
 
 <a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#cctor'></a>
 ### #cctor() `method`

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
@@ -35,15 +35,39 @@ namespace AndcultureCode.CSharp.Testing.Tests
             }
         }
 
+        /// <summary>
+        /// Cached instance of 'Faker' to use for specific data generation functions not available
+        /// from Randomizer (such as email addresses, ip addresses, names, etc.)
+        /// </summary>
+        /// <returns></returns>
+        protected Faker Faker => _faker = _faker ?? new Faker();
+
         protected ITestOutputHelper Output { get; private set; }
 
-        protected Randomizer Random => _randomizer = _randomizer ?? new Randomizer();
+        /// <summary>
+        /// Wrapper property for accessing the 'Randomizer' instance of 'Faker' directly. This field
+        /// will instantiate a new Faker instance if it has not yet been accessed directly.
+        /// </summary>
+        /// <value></value>
+        protected Randomizer Random
+        {
+            get
+            {
+                if (_faker == null)
+                {
+                    _faker = new Faker();
+                }
+
+                return _faker.Random;
+            }
+        }
 
         #endregion Protected Properties
 
         #region Private Properties
 
-        private Randomizer _randomizer;
+        private Faker _faker;
+        private ILoggerFactory _loggerFactory;
 
         #endregion Private Properties
 
@@ -86,12 +110,6 @@ namespace AndcultureCode.CSharp.Testing.Tests
         }
 
         #endregion Teardown
-
-        #region Member Variables
-
-        private ILoggerFactory _loggerFactory;
-
-        #endregion Member Variables
 
         #region Protected Methods
 

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
@@ -49,18 +49,7 @@ namespace AndcultureCode.CSharp.Testing.Tests
         /// will instantiate a new Faker instance if it has not yet been accessed directly.
         /// </summary>
         /// <value></value>
-        protected Randomizer Random
-        {
-            get
-            {
-                if (_faker == null)
-                {
-                    _faker = new Faker();
-                }
-
-                return _faker.Random;
-            }
-        }
+        protected Randomizer Random => Faker.Random;
 
         #endregion Protected Properties
 

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
@@ -19,9 +19,10 @@ namespace AndcultureCode.CSharp.Testing.Tests
 {
     public class BaseTest : IDisposable
     {
-        #region Properties
+        #region Protected Properties
 
-        protected ILoggerFactory LoggerFactory {
+        protected ILoggerFactory LoggerFactory
+        {
             get
             {
                 if (_loggerFactory == null)
@@ -36,11 +37,15 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         protected ITestOutputHelper Output { get; private set; }
 
-        private   Randomizer _randomizer;
         protected Randomizer Random => _randomizer = _randomizer ?? new Randomizer();
 
-        #endregion Properties
+        #endregion Protected Properties
 
+        #region Private Properties
+
+        private Randomizer _randomizer;
+
+        #endregion Private Properties
 
         #region Constructors
 
@@ -82,31 +87,29 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         #endregion Teardown
 
-
         #region Member Variables
 
         private ILoggerFactory _loggerFactory;
 
         #endregion Member Variables
 
-
         #region Protected Methods
 
-        protected T Build<T>()                                           => FactoryExtensions.Build<T>();
-        protected T Build<T>(string name)                                => FactoryExtensions.Build<T>(name);
-        protected T Build<T>(List<string> names)                         => FactoryExtensions.Build<T>(names);
-        protected T Build<T>(Action<T> property)                         => FactoryExtensions.Build<T>(property);
-        protected T Build<T>(string name, Action<T> property)            => FactoryExtensions.Build<T>(name, property);
-        protected T Build<T>(List<Action<T>> properties)                 => FactoryExtensions.Build<T>(properties);
-        protected T Build<T>(params Action<T>[] properties)              => FactoryExtensions.Build<T>(properties.ToList());
-        protected T Build<T>(string name, List<Action<T>> properties)    => FactoryExtensions.Build<T>(name, properties);
+        protected T Build<T>() => FactoryExtensions.Build<T>();
+        protected T Build<T>(string name) => FactoryExtensions.Build<T>(name);
+        protected T Build<T>(List<string> names) => FactoryExtensions.Build<T>(names);
+        protected T Build<T>(Action<T> property) => FactoryExtensions.Build<T>(property);
+        protected T Build<T>(string name, Action<T> property) => FactoryExtensions.Build<T>(name, property);
+        protected T Build<T>(List<Action<T>> properties) => FactoryExtensions.Build<T>(properties);
+        protected T Build<T>(params Action<T>[] properties) => FactoryExtensions.Build<T>(properties.ToList());
+        protected T Build<T>(string name, List<Action<T>> properties) => FactoryExtensions.Build<T>(name, properties);
         protected T Build<T>(string name, params Action<T>[] properties) => FactoryExtensions.Build<T>(name, properties.ToList());
 
         protected List<T> BuildList<T>(int count)
         {
             var result = new List<T>();
 
-            for (var i = 1; i <= count; i ++)
+            for (var i = 1; i <= count; i++)
             {
                 result.Add(Build<T>());
             }
@@ -114,11 +117,11 @@ namespace AndcultureCode.CSharp.Testing.Tests
             return result;
         }
 
-        protected Result<T> BuildResult<T>()                                           => new Result<T> { ResultObject = FactoryExtensions.Build<T>() };
-        protected Result<T> BuildResult<T>(string name)                                => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name) };
-        protected Result<T> BuildResult<T>(Action<T> property)                         => new Result<T> { ResultObject = FactoryExtensions.Build<T>(property) };
-        protected Result<T> BuildResult<T>(string name, Action<T> property)            => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, property) };
-        protected Result<T> BuildResult<T>(List<Action<T>> properties)                 => new Result<T> { ResultObject = FactoryExtensions.Build<T>(properties) };
+        protected Result<T> BuildResult<T>() => new Result<T> { ResultObject = FactoryExtensions.Build<T>() };
+        protected Result<T> BuildResult<T>(string name) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name) };
+        protected Result<T> BuildResult<T>(Action<T> property) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(property) };
+        protected Result<T> BuildResult<T>(string name, Action<T> property) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, property) };
+        protected Result<T> BuildResult<T>(List<Action<T>> properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(properties) };
 
         /// <summary>
         /// Factory method for setting properties directly on a new Result. Sets the `ResultObject`
@@ -144,11 +147,11 @@ namespace AndcultureCode.CSharp.Testing.Tests
             return result;
         }
 
-        protected Result<T> BuildResult<T>(params Action<T>[] properties)              => new Result<T> { ResultObject = FactoryExtensions.Build<T>(properties.ToList()) };
-        protected Result<T> BuildResult<T>(string name, List<Action<T>> properties)    => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, properties) };
+        protected Result<T> BuildResult<T>(params Action<T>[] properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(properties.ToList()) };
+        protected Result<T> BuildResult<T>(string name, List<Action<T>> properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, properties) };
         protected Result<T> BuildResult<T>(string name, params Action<T>[] properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, properties.ToList()) };
 
-        protected T FromJson<T>(string value)                 => JsonConvert.DeserializeObject<T>(value);
+        protected T FromJson<T>(string value) => JsonConvert.DeserializeObject<T>(value);
         protected T FromJson<T>(HttpResponseMessage response) => response.FromJson<T>();
 
         protected byte[] GetBytes(string value) => Encoding.UTF8.GetBytes(value);

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Tests/BaseTestTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Tests/BaseTestTest.cs
@@ -1,0 +1,60 @@
+using Bogus;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndcultureCode.CSharp.Testing.Tests.Unit.Tests
+{
+    public class BaseTestTest : ProjectUnitTest
+    {
+        #region Setup
+
+        public BaseTestTest(ITestOutputHelper output) : base(output) { }
+
+        #endregion Setup
+
+        #region Faker
+
+        [Fact]
+        public void Faker_When_Accessed_Multiple_Times_Returns_Same_Instance()
+        {
+            // Arrange & Act
+            var previousInstance = Faker;
+
+            // Transitively assert the same instance through 10 accesses of `Faker`
+            for (var i = 0; i < 10; i++)
+            {
+                var currentInstance = Faker;
+
+                // Assert
+                currentInstance.ShouldBe(previousInstance);
+
+                previousInstance = currentInstance;
+            }
+        }
+
+        #endregion Faker
+
+        #region Random
+
+        [Fact]
+        public void Random_When_Accessed_Multiple_Times_Returns_Same_Instance()
+        {
+            // Arrange & Act
+            var previousInstance = Random;
+
+            // Transitively assert the same instance through 10 accesses of `Random`
+            for (var i = 0; i < 10; i++)
+            {
+                var currentInstance = Random;
+
+                // Assert
+                currentInstance.ShouldBe(previousInstance);
+
+                previousInstance = currentInstance;
+            }
+        }
+
+        #endregion Random
+    }
+}

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Tests/BaseTestTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Tests/BaseTestTest.cs
@@ -1,4 +1,3 @@
-using Bogus;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
Fixes #10 Add Faker instance to BaseTest.cs

Added a `Faker` property with caching similar to how the previous `Random` property was being managed. `Random` will now refer to the `Faker` property, which should always point to the same instance. I added tests to cover this (based on the FactorySettingsTest file), but the naming gets... weird, again. Wondering if maybe we rename the `Tests` folder in the src to `BaseTests`? 🤔

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
