### PR TITLE
add IEnumerable Shouldly matchers to IEnumerable extensions

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/Extensions/Matchers/IEnumerableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/Matchers/IEnumerableMatcherExtensions.cs
@@ -1,10 +1,101 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Shouldly;
 
 namespace AndcultureCode.CSharp.Testing.Extensions
 {
     public static class IEnumerableMatcherExtensions
     {
+        /// <summary>
+        /// Assert that an IEnumerable{T} has a certain length.
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="expectedSize"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <exception cref="ShouldAssertException"></exception>
+        public static void ShouldBeOfSize<T>(this IEnumerable<T> items, int expectedSize)
+        {
+            var actualSize = items.Count();
+            if (actualSize != expectedSize)
+            {
+                throw new ShouldAssertException(
+                    $"IEnumerable should have size {expectedSize} but actual size was {actualSize}."
+                );
+            }
+        }
+
+        /// <summary>
+        /// Assert that a list of T is ordered (ascending) by property of type V.
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="keySelector"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <exception cref="ShouldAssertException"></exception>
+        public static void ShouldBeOrderedBy<T, TValue>(
+            this IEnumerable<T> items,
+            Func<T, TValue> keySelector
+        ) where TValue : IComparable<TValue>
+        {
+            for (var i = 0; i < items.Count(); i++)
+            {
+                // we're on the last one, just continue
+                if (i == items.Count() - 1)
+                {
+                    continue;
+                }
+
+                // otherwise, compare it to the one ahead of it
+                var currentItem = keySelector(items.ElementAt(i));
+                var nextItem = keySelector(items.ElementAt(i + 1));
+
+                if (currentItem.CompareTo(nextItem) > 0)
+                {
+                    var message = new StringBuilder("Items should be ordered ascending but are not.");
+                    message.AppendLine($"\nSelected key for elements[{i}]: {currentItem}");
+                    message.AppendLine($"Selected key for elements[{i + 1}]: {nextItem}");
+                    throw new ShouldAssertException(message.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Assert that a list of T is ordered (descending) by property of type V.
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="keySelector"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        /// <exception cref="ShouldAssertException"></exception>
+        public static void ShouldBeOrderedByDescending<T, TValue>(
+            this IEnumerable<T> items,
+            Func<T, TValue> keySelector
+        ) where TValue : IComparable<TValue>
+        {
+            for (var i = 0; i < items.Count(); i++)
+            {
+                // we're on the last one, just continue
+                if (i == items.Count() - 1)
+                {
+                    continue;
+                }
+
+                // otherwise, compare it to the one ahead of it
+                var currentItem = keySelector(items.ElementAt(i));
+                var nextItem = keySelector(items.ElementAt(i + 1));
+
+                if (currentItem.CompareTo(nextItem) < 0)
+                {
+                    var message = new StringBuilder("Items should be ordered descending but are not.");
+                    message.AppendLine($"\nSelected key for elements[{i}]: {currentItem}");
+                    message.AppendLine($"Selected key for elements[{i + 1}]: {nextItem}");
+                    throw new ShouldAssertException(message.ToString());
+                }
+            }
+        }
+
         /// <summary>
         /// Asserts if a collection contains the exact values in the supplied collection
         /// </summary>

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IEnumerableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IEnumerableMatcherExtensionsTest.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Linq;
+using AndcultureCode.CSharp.Testing.Extensions;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
+{
+    public class IEnumerableMatcherExtensionsTest : BaseUnitTest
+    {
+        #region Constructor
+
+        public IEnumerableMatcherExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        #endregion Constructor
+
+        #region ShouldBeOfSize
+
+        [Fact]
+        public void ShouldBeOfSize_When_ExpectedSize_NotEqual_ActualSize_Then_Throws_ShouldAssertException()
+        {
+            // Arrange
+            // simple trick to get a List<char> of random size
+            var items = Random.String().ToList();
+            var expectedSize = items.Count;
+            var incorrectSize = expectedSize + Random.Int(2, 5);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => items.ShouldBeOfSize(incorrectSize));
+        }
+
+        [Fact]
+        public void ShouldBeOfSize_When_ExpectedSize_Is_ActualSize_Then_Does_Not_Throw_ShouldAssertException()
+        {
+            // Arrange
+            // simple trick to get a List<char> of random size
+            var items = Random.String().ToList();
+            var expectedSize = items.Count;
+
+            // Act & Assert
+            items.ShouldBeOfSize(expectedSize);
+        }
+
+        #endregion ShouldBeOfSize
+
+        #region ShouldBeOrderedBy
+
+        [Fact]
+        public void ShouldBeOrderedBy_When_Not_Ordered_Then_Throws_ShouldAssertException()
+        {
+            // Arrange
+            var items = new List<int>();
+            var n = Random.Int(5, 25);
+            for (var i = 0; i < n; i++)
+            {
+                items.Add(Random.Int());
+            }
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => items.ShouldBeOrderedBy(e => e));
+        }
+
+        [Fact]
+        public void ShouldBeOrderedBy_When_Ordered_Then_Does_Not_Throw_ShouldAssertException()
+        {
+            // Arrange
+            var items = new List<int>();
+            var n = Random.Int(5, 25);
+            for (var i = 0; i < n; i++)
+            {
+                items.Add(i);
+            }
+
+            // Act & Assert
+            items.ShouldBeOrderedBy(e => e);
+        }
+
+        #endregion ShouldBeOrderedBy
+
+        #region ShouldBeOrderedByDescending
+
+        [Fact]
+        public void ShouldBeOrderedByDescending_When_Not_Ordered_Then_Throws_ShouldAssertException()
+        {
+            // Arrange
+            var items = new List<int>();
+            var n = Random.Int(5, 25);
+            for (var i = 0; i < n; i++)
+            {
+                items.Add(Random.Int());
+            }
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => items.ShouldBeOrderedByDescending(e => e));
+        }
+
+        [Fact]
+        public void ShouldBeOrderedByDescending_When_Ordered_Then_Does_Not_Throw_ShouldAssertException()
+        {
+            // Arrange
+            var items = new List<int>();
+            var n = Random.Int(5, 25);
+            for (var i = n; i > 0; i--)
+            {
+                items.Add(i);
+            }
+
+            // Act & Assert
+            items.ShouldBeOrderedByDescending(e => e);
+        }
+
+        #endregion ShouldBeOrderedByDescending
+    }
+}


### PR DESCRIPTION
Adds:
- `ShouldBeOfSize`
- `ShouldBeOrderedBy`
- `ShouldBeOrderedByDescending`

Fixes: #24 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
