### PR TITLE
Add testing entity and factory

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/Factories/ErrorFactory.cs
+++ b/src/AndcultureCode.CSharp.Testing/Factories/ErrorFactory.cs
@@ -1,19 +1,31 @@
-using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Core.Models.Errors;
 using AndcultureCode.CSharp.Testing.Constants;
 using CoreErrorConstants = AndcultureCode.CSharp.Core.Constants.ErrorConstants;
 
 namespace AndcultureCode.CSharp.Testing.Factories
 {
+    /// <summary>
+    /// Factory for building out configurations of the `Error` class
+    /// </summary>
     public class ErrorFactory : Factory
     {
         #region Constants
 
+        /// <summary>
+        /// Represents a basic error for testing.
+        /// </summary>
         public const string BASIC_ERROR = "BASIC_ERROR";
+
+        /// <summary>
+        /// Represents a 'RESOURCE_NOT_FOUND' error using the Core error key.
+        /// </summary>
         public const string RESOURCE_NOT_FOUND_ERROR = CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY;
 
         #endregion Constants
 
+        #region Public Methods
+
+        /// <inheritdoc />
         public override void Define()
         {
             this.DefineFactory(() => new Error
@@ -34,5 +46,7 @@ namespace AndcultureCode.CSharp.Testing.Factories
                 Message = Random.Words()
             });
         }
+
+        #endregion Public Methods
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Factories/Factory.cs
+++ b/src/AndcultureCode.CSharp.Testing/Factories/Factory.cs
@@ -4,6 +4,9 @@ using Bogus;
 
 namespace AndcultureCode.CSharp.Testing.Factories
 {
+    /// <summary>
+    /// Base factory class for building out entity configurations
+    /// </summary>
     public abstract class Factory
     {
         #region Public Methods
@@ -18,6 +21,12 @@ namespace AndcultureCode.CSharp.Testing.Factories
         #region Public Properties
 
         /// <summary>
+        /// Cached instance of 'Faker' to use for specific data generation functions not available
+        /// from Randomizer (such as email addresses, ip addresses, names, etc.)
+        /// </summary>
+        public Faker Faker => _faker = _faker ?? new Faker();
+
+        /// <summary>
         /// Returns the current time in unix milliseconds.
         ///
         /// NOTE: Not guaranteed to be unique. If you require a unique value for a factory value,
@@ -29,8 +38,7 @@ namespace AndcultureCode.CSharp.Testing.Factories
         /// <summary>
         /// Returns a cached `Randomizer` instance for generating random data as factory values.
         /// </summary>
-        /// <returns></returns>
-        public Randomizer Random => _Random = _Random ?? new Randomizer();
+        public Randomizer Random => Faker.Random;
 
         /// <summary>
         /// Returns a unique number for use in factory values.
@@ -51,7 +59,7 @@ namespace AndcultureCode.CSharp.Testing.Factories
 
         #region Private Properties
 
-        private Randomizer _Random;
+        private Faker _faker;
 
         #endregion Private Properties
     }

--- a/src/AndcultureCode.CSharp.Testing/Factories/UserStubFactory.cs
+++ b/src/AndcultureCode.CSharp.Testing/Factories/UserStubFactory.cs
@@ -1,0 +1,59 @@
+using AndcultureCode.CSharp.Testing.Models.Stubs;
+
+namespace AndcultureCode.CSharp.Testing.Factories
+{
+    /// <summary>
+    /// Factory for building out configurations of the `UserStub` class
+    /// </summary>
+    public class UserStubFactory : Factory
+    {
+        #region Constants
+
+        /// <summary>
+        /// Returns a user stub with a gmail address
+        /// </summary>
+        public const string WITH_GMAIL_EMAIL = "WITH_GMAIL_EMAIL";
+
+        /// <summary>
+        /// Returns a user stub with a yahoo address
+        /// </summary>
+        public const string WITH_YAHOO_EMAIL = "WITH_YAHOO_EMAIL";
+
+        #endregion Constants
+
+        #region Public Methods
+
+        /// <inheritdoc />
+        public override void Define()
+        {
+            this.DefineFactory(BuildDefaultUserStub);
+
+            this.DefineFactory(WITH_GMAIL_EMAIL, () =>
+            {
+                var userStub = BuildDefaultUserStub();
+                userStub.EmailAddress = $"{userStub.FirstName}{userStub.LastName}@gmail.com";
+                return userStub;
+            });
+
+            this.DefineFactory(WITH_YAHOO_EMAIL, () =>
+            {
+                var userStub = BuildDefaultUserStub();
+                userStub.EmailAddress = $"{userStub.FirstName}{userStub.LastName}@yahoo.com";
+                return userStub;
+            });
+        }
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        private UserStub BuildDefaultUserStub() => new UserStub
+        {
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.FirstName(),
+            LastName = Faker.Name.LastName(),
+        };
+
+        #endregion Private Methods
+    }
+}

--- a/src/AndcultureCode.CSharp.Testing/Models/Stubs/UserStub.cs
+++ b/src/AndcultureCode.CSharp.Testing/Models/Stubs/UserStub.cs
@@ -1,0 +1,48 @@
+using AndcultureCode.CSharp.Core.Models;
+
+namespace AndcultureCode.CSharp.Testing.Models.Stubs
+{
+    /// <summary>
+    /// Stub entity representing a User
+    /// </summary>
+    public class UserStub : Auditable
+    {
+        #region Public Properties
+
+        /// <summary>
+        /// Email address of the stub user
+        /// </summary>
+        /// <value></value>
+        public string EmailAddress { get; set; }
+
+        /// <summary>
+        /// First name of the stub user
+        /// </summary>
+        /// <value></value>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Last name of the stub user
+        /// </summary>
+        /// <value></value>
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Id of a related stub user
+        /// </summary>
+        /// <value></value>
+        public long? RelatedUserStubId { get; set; }
+
+        #endregion Public Properties
+
+        #region Navigation Properties
+
+        /// <summary>
+        /// Related stub user for testing navigation properties
+        /// </summary>
+        /// <value></value>
+        public UserStub RelatedUserStub { get; set; }
+
+        #endregion Navigation Properties
+    }
+}


### PR DESCRIPTION
Add UserStub entity inheriting from Auditable, Add Faker instance to base Factory, Add UserStubFactory based on C# Extensions repo

Resolves #23 Add basic testing entity & factory for consumer usage 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [-] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
