### PR TITLE
Feature: BaseIntegrationTest.CreateList<T>

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
+++ b/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
@@ -4,13 +4,46 @@
 ## Contents
 
 - [BaseIntegrationTest](#T-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest')
+  - [BuildTo\`\`2()](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2')
+  - [BuildTo\`\`2(name)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.String)')
+  - [BuildTo\`\`2(property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.Action{``0})')
+  - [BuildTo\`\`2(name,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.String,System.Action{``0})')
+  - [BuildTo\`\`2(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.Collections.Generic.List{System.Action{``0}})')
+  - [BuildTo\`\`2(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.Action{``0}[])')
+  - [BuildTo\`\`2(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.BuildTo``2(System.String,System.Collections.Generic.List{System.Action{``0}})')
+  - [CreateList\`\`1(count)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32)')
+  - [CreateList\`\`1(count,name)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.String)')
+  - [CreateList\`\`1(count,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.Action{``0})')
+  - [CreateList\`\`1(count,name,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.String,System.Action{``0})')
+  - [CreateList\`\`1(count,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.Collections.Generic.List{System.Action{``0}})')
+  - [CreateList\`\`1(count,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.Action{``0}[])')
+  - [CreateList\`\`1(count,name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.String,System.Collections.Generic.List{System.Action{``0}})')
+  - [CreateList\`\`1(count,name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.String,System.Action{``0}[])')
+  - [CreateList\`\`1(count,builderFunc)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Func{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateList``1(System.Int32,System.Func{``0})')
+  - [CreateTo\`\`2()](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2')
+  - [CreateTo\`\`2(name)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.String)')
+  - [CreateTo\`\`2(property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.Action{``0})')
+  - [CreateTo\`\`2(name,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.String,System.Action{``0})')
+  - [CreateTo\`\`2(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.Collections.Generic.List{System.Action{``0}})')
+  - [CreateTo\`\`2(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.Action{``0}[])')
+  - [CreateTo\`\`2(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.CreateTo``2(System.String,System.Collections.Generic.List{System.Action{``0}})')
+  - [Create\`\`1()](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1')
+  - [Create\`\`1(name)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.String)')
+  - [Create\`\`1(property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.Action{``0})')
+  - [Create\`\`1(name,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.String,System.Action{``0})')
+  - [Create\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.Collections.Generic.List{System.Action{``0}})')
+  - [Create\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.Action{``0}[])')
+  - [Create\`\`1(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.String,System.Collections.Generic.List{System.Action{``0}})')
+  - [Create\`\`1(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(System.String,System.Action{``0}[])')
   - [Create\`\`1(context,item)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-AndcultureCode-CSharp-Core-Interfaces-IContext,``0- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Create``1(AndcultureCode.CSharp.Core.Interfaces.IContext,``0)')
   - [GetRepositoryConductorDeps\`\`1(repository)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-GetRepositoryConductorDeps``1-AndcultureCode-CSharp-Core-Interfaces-Data-IRepository{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.GetRepositoryConductorDeps``1(AndcultureCode.CSharp.Core.Interfaces.Data.IRepository{``0})')
+  - [Map\`\`2(entity)](#M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Map``2-``0- 'AndcultureCode.CSharp.Testing.Tests.BaseIntegrationTest.Map``2(``0)')
 - [BaseTest](#T-AndcultureCode-CSharp-Testing-Tests-BaseTest 'AndcultureCode.CSharp.Testing.Tests.BaseTest')
   - [#ctor(output)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#ctor-Xunit-Abstractions-ITestOutputHelper- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.#ctor(Xunit.Abstractions.ITestOutputHelper)')
   - [Faker](#P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Faker 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Faker')
   - [Random](#P-AndcultureCode-CSharp-Testing-Tests-BaseTest-Random 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Random')
   - [#cctor()](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#cctor 'AndcultureCode.CSharp.Testing.Tests.BaseTest.#cctor')
+  - [BuildList\`\`1(count)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildList``1-System-Int32- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.BuildList``1(System.Int32)')
   - [BuildResult\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildResult``1-System-Action{AndcultureCode-CSharp-Core-Models-Errors-Result{``0}}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.BuildResult``1(System.Action{AndcultureCode.CSharp.Core.Models.Errors.Result{``0}}[])')
 - [ErrorFactory](#T-AndcultureCode-CSharp-Testing-Factories-ErrorFactory 'AndcultureCode.CSharp.Testing.Factories.ErrorFactory')
   - [BASIC_ERROR](#F-AndcultureCode-CSharp-Testing-Factories-ErrorFactory-BASIC_ERROR 'AndcultureCode.CSharp.Testing.Factories.ErrorFactory.BASIC_ERROR')
@@ -95,6 +128,745 @@
 
 AndcultureCode.CSharp.Testing.Tests
 
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2'></a>
+### BuildTo\`\`2() `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+This method has no parameters.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String-'></a>
+### BuildTo\`\`2(name) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Action{``0}-'></a>
+### BuildTo\`\`2(property) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String,System-Action{``0}-'></a>
+### BuildTo\`\`2(name,property) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Collections-Generic-List{System-Action{``0}}-'></a>
+### BuildTo\`\`2(properties) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-Action{``0}[]-'></a>
+### BuildTo\`\`2(properties) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-BuildTo``2-System-String,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### BuildTo\`\`2(name,properties) `method`
+
+##### Summary
+
+Builds and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32-'></a>
+### CreateList\`\`1(count) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String-'></a>
+### CreateList\`\`1(count,name) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Action{``0}-'></a>
+### CreateList\`\`1(count,property) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Action{``0}-'></a>
+### CreateList\`\`1(count,name,property) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### CreateList\`\`1(count,properties) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Action{``0}[]-'></a>
+### CreateList\`\`1(count,properties) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### CreateList\`\`1(count,name,properties) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-String,System-Action{``0}[]-'></a>
+### CreateList\`\`1(count,name,properties) `method`
+
+##### Summary
+
+Creates a list of entities of type T.
+
+##### Returns
+
+List of created entities
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Number of entities to be created |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateList``1-System-Int32,System-Func{``0}-'></a>
+### CreateList\`\`1(count,builderFunc) `method`
+
+##### Summary
+
+Helper function for the various CreateList method overloads
+
+##### Returns
+
+
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| builderFunc | [System.Func{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{``0}') |  |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T |  |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2'></a>
+### CreateTo\`\`2() `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+This method has no parameters.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String-'></a>
+### CreateTo\`\`2(name) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Action{``0}-'></a>
+### CreateTo\`\`2(property) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String,System-Action{``0}-'></a>
+### CreateTo\`\`2(name,property) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Collections-Generic-List{System-Action{``0}}-'></a>
+### CreateTo\`\`2(properties) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-Action{``0}[]-'></a>
+### CreateTo\`\`2(properties) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-CreateTo``2-System-String,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### CreateTo\`\`2(name,properties) `method`
+
+##### Summary
+
+Creates and maps an entity to the target type.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+| TTarget | Type to map entity to |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1'></a>
+### Create\`\`1() `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+This method has no parameters.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String-'></a>
+### Create\`\`1(name) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Action{``0}-'></a>
+### Create\`\`1(property) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Action{``0}-'></a>
+### Create\`\`1(name,property) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Collections-Generic-List{System-Action{``0}}-'></a>
+### Create\`\`1(properties) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-Action{``0}[]-'></a>
+### Create\`\`1(properties) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### Create\`\`1(name,properties) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-System-String,System-Action{``0}[]-'></a>
+### Create\`\`1(name,properties) `method`
+
+##### Summary
+
+Creates entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
 <a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Create``1-AndcultureCode-CSharp-Core-Interfaces-IContext,``0-'></a>
 ### Create\`\`1(context,item) `method`
 
@@ -141,6 +913,30 @@ Sets up an object containing conductor dependencies for a given Entity T returne
 | Name | Description |
 | ---- | ----------- |
 | T |  |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseIntegrationTest-Map``2-``0-'></a>
+### Map\`\`2(entity) `method`
+
+##### Summary
+
+Maps an entity to the target type
+
+##### Returns
+
+Mapped entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| entity | [\`\`0](#T-``0 '``0') |  |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Source type of entity |
+| TTarget | Destination type to map entity to |
 
 <a name='T-AndcultureCode-CSharp-Testing-Tests-BaseTest'></a>
 ## BaseTest `type`
@@ -194,6 +990,29 @@ Static constructor to set up suite-level actors
 ##### Parameters
 
 This method has no parameters.
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildList``1-System-Int32-'></a>
+### BuildList\`\`1(count) `method`
+
+##### Summary
+
+Builds a list of entity type T. A factory for type T must be defined.
+
+##### Returns
+
+
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildResult``1-System-Action{AndcultureCode-CSharp-Core-Models-Errors-Result{``0}}[]-'></a>
 ### BuildResult\`\`1(properties) `method`

--- a/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
+++ b/src/AndcultureCode.CSharp.Testing/AndcultureCode.CSharp.Testing.md
@@ -45,6 +45,14 @@
   - [#cctor()](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-#cctor 'AndcultureCode.CSharp.Testing.Tests.BaseTest.#cctor')
   - [BuildList\`\`1(count)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildList``1-System-Int32- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.BuildList``1(System.Int32)')
   - [BuildResult\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-BuildResult``1-System-Action{AndcultureCode-CSharp-Core-Models-Errors-Result{``0}}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.BuildResult``1(System.Action{AndcultureCode.CSharp.Core.Models.Errors.Result{``0}}[])')
+  - [Build\`\`1()](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1')
+  - [Build\`\`1(name)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.String)')
+  - [Build\`\`1(property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.Action{``0})')
+  - [Build\`\`1(name,property)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Action{``0}- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.String,System.Action{``0})')
+  - [Build\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.Collections.Generic.List{System.Action{``0}})')
+  - [Build\`\`1(properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.Action{``0}[])')
+  - [Build\`\`1(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Collections-Generic-List{System-Action{``0}}- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.String,System.Collections.Generic.List{System.Action{``0}})')
+  - [Build\`\`1(name,properties)](#M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Action{``0}[]- 'AndcultureCode.CSharp.Testing.Tests.BaseTest.Build``1(System.String,System.Action{``0}[])')
 - [ErrorFactory](#T-AndcultureCode-CSharp-Testing-Factories-ErrorFactory 'AndcultureCode.CSharp.Testing.Factories.ErrorFactory')
   - [BASIC_ERROR](#F-AndcultureCode-CSharp-Testing-Factories-ErrorFactory-BASIC_ERROR 'AndcultureCode.CSharp.Testing.Factories.ErrorFactory.BASIC_ERROR')
   - [RESOURCE_NOT_FOUND_ERROR](#F-AndcultureCode-CSharp-Testing-Factories-ErrorFactory-RESOURCE_NOT_FOUND_ERROR 'AndcultureCode.CSharp.Testing.Factories.ErrorFactory.RESOURCE_NOT_FOUND_ERROR')
@@ -1038,6 +1046,191 @@ configuration of \`T\` is required.
 | Name | Description |
 | ---- | ----------- |
 | T |  |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1'></a>
+### Build\`\`1() `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+This method has no parameters.
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String-'></a>
+### Build\`\`1(name) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Action{``0}-'></a>
+### Build\`\`1(property) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Action{``0}-'></a>
+### Build\`\`1(name,property) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| property | [System.Action{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}') | Function to set a specific property on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Collections-Generic-List{System-Action{``0}}-'></a>
+### Build\`\`1(properties) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-Action{``0}[]-'></a>
+### Build\`\`1(properties) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Collections-Generic-List{System-Action{``0}}-'></a>
+### Build\`\`1(name,properties) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Collections.Generic.List{System.Action{\`\`0}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.Action{``0}}') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
+
+<a name='M-AndcultureCode-CSharp-Testing-Tests-BaseTest-Build``1-System-String,System-Action{``0}[]-'></a>
+### Build\`\`1(name,properties) `method`
+
+##### Summary
+
+Builds entity of type T.
+
+##### Returns
+
+Created entity
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Named factory to be used for creation |
+| properties | [System.Action{\`\`0}[]](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Action 'System.Action{``0}[]') | Functions to set properties on the created entity |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T | Type of entity to create |
 
 <a name='T-AndcultureCode-CSharp-Testing-Factories-ErrorFactory'></a>
 ## ErrorFactory `type`

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseIntegrationTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseIntegrationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using AndcultureCode.CSharp.Conductors;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Core.Interfaces.Conductors;
@@ -42,25 +43,143 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         #region BuildTo
 
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
         protected TTarget BuildTo<T, TTarget>() => Mapper.Map<T, TTarget>(Build<T>());
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
         protected TTarget BuildTo<T, TTarget>(string name) => Mapper.Map<T, TTarget>(Build<T>(name));
-        protected TTarget BuildTo<T, TTarget>(Action<T> property) => Mapper.Map<T, TTarget>(Build<T>(property));
-        protected TTarget BuildTo<T, TTarget>(string name, Action<T> property) => Mapper.Map<T, TTarget>(Build<T>(name, property));
-        protected TTarget BuildTo<T, TTarget>(List<Action<T>> properties) => Mapper.Map<T, TTarget>(Build<T>(properties));
-        protected TTarget BuildTo<T, TTarget>(params Action<T>[] properties) => Mapper.Map<T, TTarget>(Build<T>(properties));
-        protected TTarget BuildTo<T, TTarget>(string name, List<Action<T>> properties) => Mapper.Map<T, TTarget>(Build<T>(name, properties));
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget BuildTo<T, TTarget>(Action<T> property) =>
+            Mapper.Map<T, TTarget>(Build<T>(property));
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget BuildTo<T, TTarget>(string name, Action<T> property) =>
+            Mapper.Map<T, TTarget>(Build<T>(name, property));
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget BuildTo<T, TTarget>(List<Action<T>> properties) =>
+            Mapper.Map<T, TTarget>(Build<T>(properties));
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget BuildTo<T, TTarget>(params Action<T>[] properties) =>
+            Mapper.Map<T, TTarget>(Build<T>(properties));
+
+        /// <summary>
+        /// Builds and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget BuildTo<T, TTarget>(string name, List<Action<T>> properties) =>
+            Mapper.Map<T, TTarget>(Build<T>(name, properties));
 
         #endregion BuildTo
 
         #region Create
 
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>() where T : Entity => Create(Context, Build<T>());
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(string name) where T : Entity => Create(Context, Build<T>(name));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(Action<T> property) where T : Entity => Create(Context, Build<T>(property));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(string name, Action<T> property) where T : Entity => Create(Context, Build<T>(name, property));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(List<Action<T>> properties) where T : Entity => Create(Context, Build<T>(properties));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(params Action<T>[] properties) where T : Entity => Create(Context, Build<T>(properties));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(string name, List<Action<T>> properties) where T : Entity => Create(Context, Build<T>(name, properties));
+
+        /// <summary>
+        /// Creates entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Create<T>(string name, params Action<T>[] properties) where T : Entity => Create(Context, Build<T>(name, properties));
 
         #endregion Create
@@ -68,37 +187,173 @@ namespace AndcultureCode.CSharp.Testing.Tests
         #region CreateList
 
         /// <summary>
-        /// Creates a list of entity type T. A factory for type T must be defined.
+        /// Creates a list of entities of type T.
         /// </summary>
-        /// <param name="count"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        protected List<T> CreateList<T>(int count) where T : Entity
-        {
-            var entities = new List<T>();
-            for (var i = 0; i < count; i++)
-            {
-                entities.Add(Create(Context, Build<T>()));
-            }
+        /// <param name="count">Number of entities to be created</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count) where T : Entity =>
+            CreateList<T>(count, () => Create<T>());
 
-            return entities;
-        }
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, string name) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(name));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, Action<T> property) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(property));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, string name, Action<T> property) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(name, property));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, List<Action<T>> properties) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(properties));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, params Action<T>[] properties) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(properties));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, string name, List<Action<T>> properties) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(name, properties));
+
+        /// <summary>
+        /// Creates a list of entities of type T.
+        /// </summary>
+        /// <param name="count">Number of entities to be created</param>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>List of created entities</returns>
+        protected List<T> CreateList<T>(int count, string name, params Action<T>[] properties) where T : Entity =>
+            CreateList<T>(count, () => Create<T>(name, properties));
 
         #endregion CreateList
 
         #region CreateTo
 
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
         protected TTarget CreateTo<T, TTarget>() where T : Entity => Mapper.Map<T, TTarget>(Create<T>());
-        protected TTarget CreateTo<T, TTarget>(string name) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name));
-        protected TTarget CreateTo<T, TTarget>(Action<T> property) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(property));
-        protected TTarget CreateTo<T, TTarget>(string name, Action<T> property) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, property));
-        protected TTarget CreateTo<T, TTarget>(List<Action<T>> properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
-        protected TTarget CreateTo<T, TTarget>(params Action<T>[] properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
-        protected TTarget CreateTo<T, TTarget>(string name, List<Action<T>> properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, properties));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(string name) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(name));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(Action<T> property) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(property));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(string name, Action<T> property) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(name, property));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(List<Action<T>> properties) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(properties));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(params Action<T>[] properties) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(properties));
+
+        /// <summary>
+        /// Creates and maps an entity to the target type.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <typeparam name="TTarget">Type to map entity to</typeparam>
+        /// <returns>Created entity</returns>
+        protected TTarget CreateTo<T, TTarget>(string name, List<Action<T>> properties) where T : Entity =>
+            Mapper.Map<T, TTarget>(Create<T>(name, properties));
 
         #endregion CreateTo
 
+        /// <summary>
+        /// Maps an entity to the target type
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <typeparam name="T">Source type of entity</typeparam>
+        /// <typeparam name="TTarget">Destination type to map entity to</typeparam>
+        /// <returns>Mapped entity</returns>
         protected TTarget Map<T, TTarget>(T entity) => Mapper.Map<T, TTarget>(entity);
+
+        #endregion Protected Methods
 
         #region Virtual Methods
 
@@ -152,5 +407,27 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         #endregion Conductors
 
+        #region Private Methods
+
+        /// <summary>
+        /// Helper function for the various CreateList method overloads
+        /// </summary>
+        /// <param name="count"></param>
+        /// <param name="builderFunc"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        private List<T> CreateList<T>(int count, Func<T> builderFunc)
+        {
+            var entities = new List<T>();
+
+            for (var i = 0; i < count; i++)
+            {
+                entities.Add(builderFunc());
+            }
+
+            return entities;
+        }
+
+        #endregion Private Methods
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseIntegrationTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseIntegrationTest.cs
@@ -22,9 +22,7 @@ namespace AndcultureCode.CSharp.Testing.Tests
         protected virtual IMapper Mapper { get; set; }
         protected virtual IRepository<Entity> Repository { get; set; }
 
-
-        #endregion
-
+        #endregion Member Variables
 
         #region Constructor
 
@@ -34,45 +32,73 @@ namespace AndcultureCode.CSharp.Testing.Tests
             IRepository<Entity> repository = null
         ) : base(output)
         {
-            Context    = context;
+            Context = context;
             Repository = repository;
         }
 
-        #endregion
-
+        #endregion Constructor
 
         #region Protected Methods
 
-        #region Factories
+        #region BuildTo
 
-        protected TTarget BuildTo<T, TTarget>()                                        => Mapper.Map<T, TTarget>(Build<T>());
-        protected TTarget BuildTo<T, TTarget>(string name)                             => Mapper.Map<T, TTarget>(Build<T>(name));
-        protected TTarget BuildTo<T, TTarget>(Action<T> property)                      => Mapper.Map<T, TTarget>(Build<T>(property));
-        protected TTarget BuildTo<T, TTarget>(string name, Action<T> property)         => Mapper.Map<T, TTarget>(Build<T>(name, property));
-        protected TTarget BuildTo<T, TTarget>(List<Action<T>> properties)              => Mapper.Map<T, TTarget>(Build<T>(properties));
-        protected TTarget BuildTo<T, TTarget>(params Action<T>[] properties)           => Mapper.Map<T, TTarget>(Build<T>(properties));
+        protected TTarget BuildTo<T, TTarget>() => Mapper.Map<T, TTarget>(Build<T>());
+        protected TTarget BuildTo<T, TTarget>(string name) => Mapper.Map<T, TTarget>(Build<T>(name));
+        protected TTarget BuildTo<T, TTarget>(Action<T> property) => Mapper.Map<T, TTarget>(Build<T>(property));
+        protected TTarget BuildTo<T, TTarget>(string name, Action<T> property) => Mapper.Map<T, TTarget>(Build<T>(name, property));
+        protected TTarget BuildTo<T, TTarget>(List<Action<T>> properties) => Mapper.Map<T, TTarget>(Build<T>(properties));
+        protected TTarget BuildTo<T, TTarget>(params Action<T>[] properties) => Mapper.Map<T, TTarget>(Build<T>(properties));
         protected TTarget BuildTo<T, TTarget>(string name, List<Action<T>> properties) => Mapper.Map<T, TTarget>(Build<T>(name, properties));
 
-        protected T Create<T>()                                           where T : Entity => Create(Context, Build<T>());
-        protected T Create<T>(string name)                                where T : Entity => Create(Context, Build<T>(name));
-        protected T Create<T>(Action<T> property)                         where T : Entity => Create(Context, Build<T>(property));
-        protected T Create<T>(string name, Action<T> property)            where T : Entity => Create(Context, Build<T>(name, property));
-        protected T Create<T>(List<Action<T>> properties)                 where T : Entity => Create(Context, Build<T>(properties));
-        protected T Create<T>(params Action<T>[] properties)              where T : Entity => Create(Context, Build<T>(properties));
-        protected T Create<T>(string name, List<Action<T>> properties)    where T : Entity => Create(Context, Build<T>(name, properties));
+        #endregion BuildTo
+
+        #region Create
+
+        protected T Create<T>() where T : Entity => Create(Context, Build<T>());
+        protected T Create<T>(string name) where T : Entity => Create(Context, Build<T>(name));
+        protected T Create<T>(Action<T> property) where T : Entity => Create(Context, Build<T>(property));
+        protected T Create<T>(string name, Action<T> property) where T : Entity => Create(Context, Build<T>(name, property));
+        protected T Create<T>(List<Action<T>> properties) where T : Entity => Create(Context, Build<T>(properties));
+        protected T Create<T>(params Action<T>[] properties) where T : Entity => Create(Context, Build<T>(properties));
+        protected T Create<T>(string name, List<Action<T>> properties) where T : Entity => Create(Context, Build<T>(name, properties));
         protected T Create<T>(string name, params Action<T>[] properties) where T : Entity => Create(Context, Build<T>(name, properties));
 
-        protected TTarget CreateTo<T, TTarget>()                                         where T : Entity => Mapper.Map<T, TTarget>(Create<T>());
-        protected TTarget CreateTo<T, TTarget>(string name)                              where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name));
-        protected TTarget CreateTo<T, TTarget>(Action<T> property)                       where T : Entity => Mapper.Map<T, TTarget>(Create<T>(property));
-        protected TTarget CreateTo<T, TTarget>(string name, Action<T> property)          where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, property));
-        protected TTarget CreateTo<T, TTarget>(List<Action<T>> properties)               where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
-        protected TTarget CreateTo<T, TTarget>(params Action<T>[] properties)            where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
-        protected TTarget CreateTo<T, TTarget>(string name, List<Action<T>> properties)  where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, properties));
+        #endregion Create
+
+        #region CreateList
+
+        /// <summary>
+        /// Creates a list of entity type T. A factory for type T must be defined.
+        /// </summary>
+        /// <param name="count"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        protected List<T> CreateList<T>(int count) where T : Entity
+        {
+            var entities = new List<T>();
+            for (var i = 0; i < count; i++)
+            {
+                entities.Add(Create(Context, Build<T>()));
+            }
+
+            return entities;
+        }
+
+        #endregion CreateList
+
+        #region CreateTo
+
+        protected TTarget CreateTo<T, TTarget>() where T : Entity => Mapper.Map<T, TTarget>(Create<T>());
+        protected TTarget CreateTo<T, TTarget>(string name) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name));
+        protected TTarget CreateTo<T, TTarget>(Action<T> property) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(property));
+        protected TTarget CreateTo<T, TTarget>(string name, Action<T> property) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, property));
+        protected TTarget CreateTo<T, TTarget>(List<Action<T>> properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
+        protected TTarget CreateTo<T, TTarget>(params Action<T>[] properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(properties));
+        protected TTarget CreateTo<T, TTarget>(string name, List<Action<T>> properties) where T : Entity => Mapper.Map<T, TTarget>(Create<T>(name, properties));
+
+        #endregion CreateTo
 
         protected TTarget Map<T, TTarget>(T entity) => Mapper.Map<T, TTarget>(entity);
-
-        #endregion Factories
 
         #region Virtual Methods
 
@@ -85,7 +111,7 @@ namespace AndcultureCode.CSharp.Testing.Tests
         /// <returns>NotImplementedException when not overridden</returns>
         public virtual T Create<T>(IContext context, T item) where T : Entity => throw new NotImplementedException();
 
-        #endregion
+        #endregion Virtual Methods
 
         #region Conductors
 
@@ -97,20 +123,20 @@ namespace AndcultureCode.CSharp.Testing.Tests
         /// <returns></returns>
         protected IntegrationTestConductors<T> GetRepositoryConductorDeps<T>(IRepository<T> repository) where T : Entity
         {
-            var create     = new RepositoryCreateConductor<T>(repository);
-            var delete     = new RepositoryDeleteConductor<T>(repository);
-            var read       = new RepositoryReadConductor<T>  (repository);
-            var update     = new RepositoryUpdateConductor<T>(repository);
-            var conductor  = new RepositoryConductor<T>(create, read, update, delete);
+            var create = new RepositoryCreateConductor<T>(repository);
+            var delete = new RepositoryDeleteConductor<T>(repository);
+            var read = new RepositoryReadConductor<T>(repository);
+            var update = new RepositoryUpdateConductor<T>(repository);
+            var conductor = new RepositoryConductor<T>(create, read, update, delete);
 
             return new IntegrationTestConductors<T>
             {
-                Conductor  = conductor,
-                Create     = create,
-                Delete     = delete,
-                Read       = read,
+                Conductor = conductor,
+                Create = create,
+                Delete = delete,
+                Read = read,
                 Repository = repository,
-                Update     = update
+                Update = update
             };
         }
 
@@ -120,10 +146,11 @@ namespace AndcultureCode.CSharp.Testing.Tests
         /// <param name="customContext"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        protected IRepositoryConductor<T> SetupRepositoryConductor<T>(IRepository<T> customRepository = null) where T : Entity => GetRepositoryConductorDeps<T>(customRepository).Conductor;
+        protected IRepositoryConductor<T> SetupRepositoryConductor<T>(
+            IRepository<T> customRepository = null
+        ) where T : Entity => GetRepositoryConductorDeps<T>(customRepository).Conductor;
 
         #endregion Conductors
 
-        #endregion
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
@@ -104,6 +104,8 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         #region Protected Methods
 
+        #region Build
+
         protected T Build<T>() => FactoryExtensions.Build<T>();
         protected T Build<T>(string name) => FactoryExtensions.Build<T>(name);
         protected T Build<T>(List<string> names) => FactoryExtensions.Build<T>(names);
@@ -114,6 +116,16 @@ namespace AndcultureCode.CSharp.Testing.Tests
         protected T Build<T>(string name, List<Action<T>> properties) => FactoryExtensions.Build<T>(name, properties);
         protected T Build<T>(string name, params Action<T>[] properties) => FactoryExtensions.Build<T>(name, properties.ToList());
 
+        #endregion Build
+
+        #region BuildList
+
+        /// <summary>
+        /// Builds a list of entity type T. A factory for type T must be defined.
+        /// </summary>
+        /// <param name="count"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         protected List<T> BuildList<T>(int count)
         {
             var result = new List<T>();
@@ -125,6 +137,10 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
             return result;
         }
+
+        #endregion BuildList
+
+        #region BuildResult
 
         protected Result<T> BuildResult<T>() => new Result<T> { ResultObject = FactoryExtensions.Build<T>() };
         protected Result<T> BuildResult<T>(string name) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name) };
@@ -159,6 +175,8 @@ namespace AndcultureCode.CSharp.Testing.Tests
         protected Result<T> BuildResult<T>(params Action<T>[] properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(properties.ToList()) };
         protected Result<T> BuildResult<T>(string name, List<Action<T>> properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, properties) };
         protected Result<T> BuildResult<T>(string name, params Action<T>[] properties) => new Result<T> { ResultObject = FactoryExtensions.Build<T>(name, properties.ToList()) };
+
+        #endregion BuildResult
 
         protected T FromJson<T>(string value) => JsonConvert.DeserializeObject<T>(value);
         protected T FromJson<T>(HttpResponseMessage response) => response.FromJson<T>();

--- a/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
+++ b/src/AndcultureCode.CSharp.Testing/Tests/BaseTest.cs
@@ -106,14 +106,72 @@ namespace AndcultureCode.CSharp.Testing.Tests
 
         #region Build
 
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>() => FactoryExtensions.Build<T>();
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(string name) => FactoryExtensions.Build<T>(name);
+
         protected T Build<T>(List<string> names) => FactoryExtensions.Build<T>(names);
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(Action<T> property) => FactoryExtensions.Build<T>(property);
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="property">Function to set a specific property on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(string name, Action<T> property) => FactoryExtensions.Build<T>(name, property);
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(List<Action<T>> properties) => FactoryExtensions.Build<T>(properties);
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(params Action<T>[] properties) => FactoryExtensions.Build<T>(properties.ToList());
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(string name, List<Action<T>> properties) => FactoryExtensions.Build<T>(name, properties);
+
+        /// <summary>
+        /// Builds entity of type T.
+        /// </summary>
+        /// <param name="name">Named factory to be used for creation</param>
+        /// <param name="properties">Functions to set properties on the created entity</param>
+        /// <typeparam name="T">Type of entity to create</typeparam>
+        /// <returns>Created entity</returns>
         protected T Build<T>(string name, params Action<T>[] properties) => FactoryExtensions.Build<T>(name, properties.ToList());
 
         #endregion Build


### PR DESCRIPTION
Closes #16 Add CreateList<T> to BaseIntegrationTest 

Adds various `CreateList<T>` overloads and backfills some XML documentation

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [-] No _decreases_ in automated test coverage
    - Not 100% sure of a good way to test this aside from writing in a stub implementation of the `BaseIntegrationTest`. 
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
