### PR TITLE
IResult<IAuditable> matcher extensions

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -32,18 +32,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <param name="exactCount">When supplied, asserts the result has this exact number of errors</param>
         public static void ShouldHaveErrors(this IResult<bool> result, int? exactCount = null)
         {
-            result.ShouldNotBeNull();
-            result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
-            result.Errors.Count.ShouldBeGreaterThan(0);
-            result.ErrorCount.ShouldBeGreaterThan(0);
-            result.HasErrors.ShouldBeTrue(result.ListErrors());
+            result.ShouldHaveErrors<bool>(exactCount);
             result.ResultObject.ShouldBeFalse();
-
-            if (exactCount != null)
-            {
-                result.ErrorCount.ShouldBe((int)exactCount);
-                result.Errors.Count.ShouldBe((int)exactCount);
-            }
         }
 
         #endregion IResult<bool> Extensions
@@ -69,12 +59,12 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
             result.Errors.Count.ShouldBeGreaterThan(0);
             result.ErrorCount.ShouldBeGreaterThan(0);
-            result.HasErrors.ShouldBeTrue(result.ListErrors());
+            result.HasErrors.ShouldBeTrue();
 
             if (exactCount != null)
             {
                 result.ErrorCount.ShouldBe((int)exactCount);
-                result.Errors.Count.ShouldBe((int)exactCount);
+                result.Errors.ShouldBeOfSize((int)exactCount);
             }
         }
 
@@ -88,22 +78,25 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <param name="containedInMessage">When supplied, asserts that the property's error message contains this string</param>
         public static void ShouldHaveErrorsFor<T>(this IResult<T> result, string property, int? exactCount = null, string containedInMessage = null)
         {
-            result.ShouldNotBeNull();
-            result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
-            result.Errors.ShouldContain(e => e.Key == property, result.ListErrors());
-            result.ErrorCount.ShouldBeGreaterThan(0);
-            result.HasErrors.ShouldBeTrue();
+            result.ShouldHaveErrors<T>();
+            result.Errors.ShouldContain(
+                elementPredicate: (e) => e.Key == property,
+                customMessage: $"Expected error '{property}' but did not: {result.ListErrors()}"
+            );
 
             if (!string.IsNullOrWhiteSpace(containedInMessage))
             {
                 containedInMessage = containedInMessage.ToLower();
 
-                result.Errors.ShouldContain(e => e.Key == property && e.Message.ToLower().Contains(containedInMessage), result.ListErrors());
+                result.Errors.ShouldContain(
+                    elementPredicate: (e) => e.Key == property && e.Message.ToLower().Contains(containedInMessage),
+                    customMessage: $"Expected error '{property}' to contain '{containedInMessage}' in message, but did not: {result.ListErrors()}"
+                );
             }
 
             if (exactCount != null)
             {
-                result.Errors.Where(e => e.Key == property).Count().ShouldBe((int)exactCount);
+                result.Errors.Where((e) => e.Key == property).ShouldBeOfSize((int)exactCount);
             }
         }
 
@@ -140,7 +133,10 @@ namespace AndcultureCode.CSharp.Testing.Extensions
                 return;
             }
 
-            result.Errors.ShouldNotContain(e => e.Key == property);
+            result.Errors.ShouldNotContain(
+                elementPredicate: (e) => e.Key == property,
+                customMessage: $"Expected not to have an error with key '{property}' but found: {result.ListErrors()}"
+            );
         }
 
         #endregion IResult<T> Extensions

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -107,6 +107,40 @@ namespace AndcultureCode.CSharp.Testing.Extensions
 
         #endregion IResult<IDeletable> Extensions
 
+        #region IResult<IUpdatable> Extensions
+
+        /// <summary>
+        /// Assert that the `ResultObject` has an `UpdatedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldBeUpdated<TUpdatable>(this IResult<TUpdatable> result) where TUpdatable : IUpdatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.UpdatedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `UpdatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="updatedById">Expected id of the record's updater</param>
+        public static void ShouldBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, long updatedById)
+            where TUpdatable : IUpdatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.UpdatedById.ShouldBe(updatedById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `UpdatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="updatedBy">Expected record's updater</param>
+        public static void ShouldBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, IEntity updatedBy)
+            where TUpdatable : IUpdatable => result.ShouldBeUpdatedBy(updatedBy.Id);
+
+        #endregion IResult<IUpdatable> Extensions
+
         #region IResult<T> Extensions
 
         /// <summary>

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -45,7 +45,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// Assert that the `ResultObject` has a `CreatedOn` value
         /// </summary>
         /// <param name="result">Result under test</param>
-        public static void ShouldBeCreated(this IResult<ICreatable> result)
+        public static void ShouldBeCreated<TCreatable>(this IResult<TCreatable> result) where TCreatable : ICreatable
         {
             result.ShouldHaveResultObject();
             result.ResultObject.CreatedOn.ShouldNotBeNull();
@@ -56,7 +56,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// </summary>
         /// <param name="result">Result under test</param>
         /// <param name="createdById">Expected id of the record's creator</param>
-        public static void ShouldBeCreatedBy(this IResult<ICreatable> result, long createdById)
+        public static void ShouldBeCreatedBy<TCreatable>(this IResult<TCreatable> result, long createdById)
+            where TCreatable : ICreatable
         {
             result.ShouldHaveResultObject();
             result.ResultObject.CreatedById.ShouldBe(createdById);
@@ -67,8 +68,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// </summary>
         /// <param name="result">Result under test</param>
         /// <param name="createdBy">Expected record's creator</param>
-        public static void ShouldBeCreatedBy(this IResult<ICreatable> result, IEntity createdBy) =>
-            result.ShouldBeCreatedBy(createdBy.Id);
+        public static void ShouldBeCreatedBy<TCreatable>(this IResult<TCreatable> result, IEntity createdBy)
+            where TCreatable : ICreatable => result.ShouldBeCreatedBy(createdBy.Id);
 
         #endregion IResult<ICreatable> Extensions
 

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -4,6 +4,7 @@ using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Testing.Constants;
 using Shouldly;
 using CoreErrorConstants = AndcultureCode.CSharp.Core.Constants.ErrorConstants;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
 
 namespace AndcultureCode.CSharp.Testing.Extensions
 {
@@ -37,6 +38,39 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         }
 
         #endregion IResult<bool> Extensions
+
+        #region IResult<ICreatable> Extensions
+
+        /// <summary>
+        /// Assert that the `ResultObject` has a `CreatedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldBeCreated(this IResult<ICreatable> result)
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.CreatedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `CreatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="createdById">Expected id of the record's creator</param>
+        public static void ShouldBeCreatedBy(this IResult<ICreatable> result, long createdById)
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.CreatedById.ShouldBe(createdById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `CreatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="createdBy">Expected record's creator</param>
+        public static void ShouldBeCreatedBy(this IResult<ICreatable> result, IEntity createdBy) =>
+            result.ShouldBeCreatedBy(createdBy.Id);
+
+        #endregion IResult<ICreatable> Extensions
 
         #region IResult<T> Extensions
 
@@ -107,6 +141,17 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <typeparam name="T"></typeparam>
         public static void ShouldHaveResourceNotFoundError<T>(this IResult<T> result) =>
             result.ShouldHaveErrorsFor(CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY);
+
+        /// <summary>
+        /// Assert that `ResultObject` is not null
+        /// </summary>
+        /// <param name="result"></param>
+        /// <typeparam name="T"></typeparam>
+        public static void ShouldHaveResultObject<T>(this IResult<T> result)
+        {
+            result.ShouldNotBeNull();
+            result.ResultObject.ShouldNotBeNull($"Expected {nameof(IResult<T>.ResultObject)} to have a value, but it was null.");
+        }
 
         /// <summary>
         /// Assert that there are no errors for the given result

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -5,6 +5,7 @@ using AndcultureCode.CSharp.Testing.Constants;
 using Shouldly;
 using CoreErrorConstants = AndcultureCode.CSharp.Core.Constants.ErrorConstants;
 using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using System.Collections.Generic;
 
 namespace AndcultureCode.CSharp.Testing.Extensions
 {
@@ -147,7 +148,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// Assert result has error for `BASIC_ERROR_KEY`
         /// </summary>
         /// <param name="result">Result under test</param>
-        /// <typeparam name="T"></typeparam>
         public static void ShouldHaveBasicError<T>(this IResult<T> result) => result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);
 
         /// <summary>
@@ -155,7 +155,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// </summary>
         /// <param name="result">Result under test</param>
         /// <param name="exactCount">When supplied, asserts the result has this exact number of errors</param>
-        /// <typeparam name="T"></typeparam>
         public static void ShouldHaveErrors<T>(this IResult<T> result, int? exactCount = null)
         {
             result.ShouldNotBeNull();
@@ -174,7 +173,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <summary>
         /// Assert that there are errors for the supplied property
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="result">Result under test</param>
         /// <param name="property">Key of the error to be asserted against</param>
         /// <param name="exactCount">When supplied, asserts the exact number of errors with the property. NOT total number of errors</param>
@@ -207,15 +205,13 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// Assert error exists for `ERROR_RESOURCE_NOT_FOUND_KEY`
         /// </summary>
         /// <param name="result">Result under test</param>
-        /// <typeparam name="T"></typeparam>
         public static void ShouldHaveResourceNotFoundError<T>(this IResult<T> result) =>
             result.ShouldHaveErrorsFor(CoreErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY);
 
         /// <summary>
         /// Assert that `ResultObject` is not null
         /// </summary>
-        /// <param name="result"></param>
-        /// <typeparam name="T"></typeparam>
+        /// <param name="result">Result under test</param>
         public static void ShouldHaveResultObject<T>(this IResult<T> result)
         {
             result.ShouldNotBeNull();
@@ -223,10 +219,26 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         }
 
         /// <summary>
+        /// Assert that an IEnumerable `ResultObject` has values
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="exactCount">When supplied, asserts that the collection has exactly this number of elements</param>
+        public static void ShouldHaveResultObjects<T>(this IResult<IEnumerable<T>> result, int? exactCount = null)
+        {
+            result.ShouldHaveResultObject();
+            if (exactCount != null)
+            {
+                result.ResultObject.ShouldBeOfSize((int)exactCount);
+                return;
+            }
+
+            result.ResultObject.ShouldNotBeEmpty();
+        }
+
+        /// <summary>
         /// Assert that there are no errors for the given result
         /// </summary>
         /// <param name="result">Result under test</param>
-        /// <typeparam name="T"></typeparam>
         public static void ShouldNotHaveErrors<T>(this IResult<T> result)
         {
             result.Errors?.Count.ShouldBe(0, $"Unexpected errors: {result.ListErrors()}");
@@ -237,7 +249,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <summary>
         /// Assert that there weren't any errors for the supplied property
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="result">Result under test</param>
         /// <param name="property">Key of the error to be asserted against</param>
         public static void ShouldNotHaveErrorsFor<T>(this IResult<T> result, string property)

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -73,6 +73,40 @@ namespace AndcultureCode.CSharp.Testing.Extensions
 
         #endregion IResult<ICreatable> Extensions
 
+        #region IResult<IDeletable> Extensions
+
+        /// <summary>
+        /// Assert that the `ResultObject` has a `DeletedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldBeDeleted<TDeletable>(this IResult<TDeletable> result) where TDeletable : IDeletable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.DeletedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `DeletedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="deletedById">Expected id of the record's deletor</param>
+        public static void ShouldBeDeletedBy<TDeletable>(this IResult<TDeletable> result, long deletedById)
+            where TDeletable : IDeletable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.DeletedById.ShouldBe(deletedById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has the expected `DeletedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="deletedBy">Expected record's deletor</param>
+        public static void ShouldBeDeletedBy<TDeletable>(this IResult<TDeletable> result, IEntity deletedBy)
+            where TDeletable : IDeletable => result.ShouldBeDeletedBy(deletedBy.Id);
+
+        #endregion IResult<IDeletable> Extensions
+
         #region IResult<T> Extensions
 
         /// <summary>

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -19,7 +19,12 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <summary>
         /// Detailed output message to display when expecting errors on a result that has a null `Errors` property
         /// </summary>
-        public const string ERROR_ERRORS_LIST_IS_NULL_MESSAGE = "Expected result to have errors, but instead Errors is 'null'";
+        public static string ERROR_ERRORS_LIST_IS_NULL_MESSAGE = $"Expected {typeof(IResult<>).Name} to have errors, but instead Errors is 'null'";
+
+        /// <summary>
+        /// Friendlier output message to display when expected entity is not valid for test assertion to continue
+        /// </summary>
+        public static string ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE = $"Expected {nameof(IEntity)} should have a value, but instead is 'null'. Verify your test arrangement is correct.";
 
         #endregion Constants
 
@@ -70,7 +75,11 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <param name="result">Result under test</param>
         /// <param name="createdBy">Expected record's creator</param>
         public static void ShouldBeCreatedBy<TCreatable>(this IResult<TCreatable> result, IEntity createdBy)
-            where TCreatable : ICreatable => result.ShouldBeCreatedBy(createdBy.Id);
+            where TCreatable : ICreatable
+        {
+            createdBy.ExpectedEntityShouldNotBeNull();
+            result.ShouldBeCreatedBy(createdBy.Id);
+        }
 
         #endregion IResult<ICreatable> Extensions
 
@@ -104,7 +113,11 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <param name="result">Result under test</param>
         /// <param name="deletedBy">Expected record's deletor</param>
         public static void ShouldBeDeletedBy<TDeletable>(this IResult<TDeletable> result, IEntity deletedBy)
-            where TDeletable : IDeletable => result.ShouldBeDeletedBy(deletedBy.Id);
+            where TDeletable : IDeletable
+        {
+            deletedBy.ExpectedEntityShouldNotBeNull();
+            result.ShouldBeDeletedBy(deletedBy.Id);
+        }
 
         #endregion IResult<IDeletable> Extensions
 
@@ -138,7 +151,11 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// <param name="result">Result under test</param>
         /// <param name="updatedBy">Expected record's updater</param>
         public static void ShouldBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, IEntity updatedBy)
-            where TUpdatable : IUpdatable => result.ShouldBeUpdatedBy(updatedBy.Id);
+            where TUpdatable : IUpdatable
+        {
+            updatedBy.ExpectedEntityShouldNotBeNull();
+            result.ShouldBeUpdatedBy(updatedBy.Id);
+        }
 
         #endregion IResult<IUpdatable> Extensions
 
@@ -267,5 +284,12 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         #endregion IResult<T> Extensions
 
         #endregion Public Methods
+
+        #region Private Methods
+
+        private static void ExpectedEntityShouldNotBeNull(this IEntity entity) =>
+            entity.ShouldNotBeNull(ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+
+        #endregion Private Methods
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -23,6 +23,33 @@ namespace AndcultureCode.CSharp.Testing.Extensions
 
         #region Public Methods
 
+        #region IResult<bool> Extensions
+
+        /// <summary>
+        /// Assert that the result has at least one error
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="exactCount">When supplied, asserts the result has this exact number of errors</param>
+        public static void ShouldHaveErrors(this IResult<bool> result, int? exactCount = null)
+        {
+            result.ShouldNotBeNull();
+            result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            result.Errors.Count.ShouldBeGreaterThan(0);
+            result.ErrorCount.ShouldBeGreaterThan(0);
+            result.HasErrors.ShouldBeTrue(result.ListErrors());
+            result.ResultObject.ShouldBeFalse();
+
+            if (exactCount != null)
+            {
+                result.ErrorCount.ShouldBe((int)exactCount);
+                result.Errors.Count.ShouldBe((int)exactCount);
+            }
+        }
+
+        #endregion IResult<bool> Extensions
+
+        #region IResult<T> Extensions
+
         /// <summary>
         /// Assert result has error for `BASIC_ERROR_KEY`
         /// </summary>
@@ -43,27 +70,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             result.Errors.Count.ShouldBeGreaterThan(0);
             result.ErrorCount.ShouldBeGreaterThan(0);
             result.HasErrors.ShouldBeTrue(result.ListErrors());
-
-            if (exactCount != null)
-            {
-                result.ErrorCount.ShouldBe((int)exactCount);
-                result.Errors.Count.ShouldBe((int)exactCount);
-            }
-        }
-
-        /// <summary>
-        /// Assert that the result has at least one error
-        /// </summary>
-        /// <param name="result">Result under test</param>
-        /// <param name="exactCount">When supplied, asserts the result has this exact number of errors</param>
-        public static void ShouldHaveErrors(this IResult<bool> result, int? exactCount = null)
-        {
-            result.ShouldNotBeNull();
-            result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
-            result.Errors.Count.ShouldBeGreaterThan(0);
-            result.ErrorCount.ShouldBeGreaterThan(0);
-            result.HasErrors.ShouldBeTrue(result.ListErrors());
-            result.ResultObject.ShouldBeFalse();
 
             if (exactCount != null)
             {
@@ -136,6 +142,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
 
             result.Errors.ShouldNotContain(e => e.Key == property);
         }
+
+        #endregion IResult<T> Extensions
 
         #endregion Public Methods
     }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -258,7 +258,6 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
         }
 
-
         [Fact]
         public void ShouldHaveErrorsFor_When_Errors_Contains_Key_Passes_Assertion()
         {
@@ -344,7 +343,6 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
                 result.ShouldHaveResourceNotFoundError();
             });
         }
-
 
         #endregion ShouldHaveResourceNotFoundError
     }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -179,7 +179,165 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             Should.NotThrow(() => result.ShouldBeCreatedBy(createdBy: expected));
         }
 
-        #endregion ShouldBeCreatedBy(long createdById)
+        #endregion ShouldBeCreatedBy(IEntity createdBy)
+
+        #region ShouldBeDeleted
+
+        [Fact]
+        public void ShouldBeDeleted_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldBeDeleted_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldBeDeleted_When_DeletedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldBeDeleted_When_DeletedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeDeleted());
+        }
+
+        #endregion ShouldBeDeleted
+
+        #region ShouldBeDeletedBy(long deletedById)
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var deletedById = Random.Long(min: 1, max: 100);
+            var unexpected = deletedById + 1;
+            var result = BuildResult<UserStub>((e) => e.DeletedById = deletedById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.DeletedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeDeletedBy(deletedById: expected));
+        }
+
+        #endregion ShouldBeDeletedBy(long deletedById)
+
+        #region ShouldBeDeletedBy(IEntity deletedBy)
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.DeletedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.DeletedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeDeletedBy(deletedBy: expected));
+        }
+
+        #endregion ShouldBeDeletedBy(IEntity deletedBy)
 
         #region ShouldHaveBasicError
 

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -9,6 +9,7 @@ using AndcultureCode.CSharp.Testing.Factories;
 using AndcultureCode.CSharp.Core.Models.Errors;
 using AndcultureCode.CSharp.Core.Interfaces.Entity;
 using AndcultureCode.CSharp.Testing.Models.Stubs;
+using System.Linq;
 
 namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 {
@@ -742,6 +743,83 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldHaveResultObject
+
+        #region ShouldHaveResultObjects
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IEnumerable<object>> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<object>>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_Empty_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = new List<UserStub>());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_HasValues_Given_Non_Matching_ExactCount_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = BuildList<UserStub>(2));
+            var unexpected = result.ResultObject.Count() + 1;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects(exactCount: unexpected));
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_HasValues_Given_Matching_ExactCount_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = BuildList<UserStub>(2));
+            var expected = result.ResultObject.Count();
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldHaveResultObjects(exactCount: expected));
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_Empty_Given_0_ExactCount_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = new List<UserStub>());
+            var expected = 0;
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldHaveResultObjects(exactCount: expected));
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_HasValues_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = BuildList<UserStub>(2));
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldHaveResultObjects());
+        }
+
+        #endregion ShouldHaveResultObjects
 
         #region ShouldHaveResourceNotFoundError
 

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -339,6 +339,164 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
         #endregion ShouldBeDeletedBy(IEntity deletedBy)
 
+        #region ShouldBeUpdated
+
+        [Fact]
+        public void ShouldBeUpdated_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldBeUpdated_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldBeUpdated_When_UpdatedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldBeUpdated_When_UpdatedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeUpdated());
+        }
+
+        #endregion ShouldBeUpdated
+
+        #region ShouldBeUpdatedBy(long updatedById)
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var updatedById = Random.Long(min: 1, max: 100);
+            var unexpected = updatedById + 1;
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = updatedById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeUpdatedBy(updatedById: expected));
+        }
+
+        #endregion ShouldBeUpdatedBy(long updatedById)
+
+        #region ShouldBeUpdatedBy(IEntity updatedBy)
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeUpdatedBy(updatedBy: expected));
+        }
+
+        #endregion ShouldBeUpdatedBy(IEntity updatedBy)
+
         #region ShouldHaveBasicError
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -128,6 +128,20 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         #region ShouldBeCreatedBy(IEntity createdBy)
 
         [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldBeCreatedBy(createdBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
         public void ShouldBeCreatedBy_CreatedBy_When_Result_Null_Fails_Assertion()
         {
             // Arrange
@@ -284,6 +298,20 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         #endregion ShouldBeDeletedBy(long deletedById)
 
         #region ShouldBeDeletedBy(IEntity deletedBy)
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldBeDeletedBy(deletedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
 
         [Fact]
         public void ShouldBeDeletedBy_DeletedBy_When_Result_Null_Fails_Assertion()
@@ -444,6 +472,20 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         #region ShouldBeUpdatedBy(IEntity updatedBy)
 
         [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldBeUpdatedBy(updatedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
         public void ShouldBeUpdatedBy_UpdatedBy_When_Result_Null_Fails_Assertion()
         {
             // Arrange
@@ -507,11 +549,11 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() => result.ShouldHaveBasicError());
+            var exception = Record.Exception(() => result.ShouldHaveBasicError());
 
             // Assert
-            ex.ShouldNotBeNull();
-            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -561,14 +603,14 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() =>
+            var exception = Record.Exception(() =>
             {
                 result.ShouldHaveErrors();
             });
 
             // Assert
-            ex.ShouldNotBeNull();
-            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -605,11 +647,11 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<bool>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() => result.ShouldHaveErrors());
+            var exception = Record.Exception(() => result.ShouldHaveErrors());
 
             // Assert
-            ex.ShouldNotBeNull();
-            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -663,11 +705,11 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() => result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY));
+            var exception = Record.Exception(() => result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY));
 
             // Assert
-            ex.ShouldNotBeNull();
-            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -830,11 +872,11 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() => result.ShouldHaveResourceNotFoundError());
+            var exception = Record.Exception(() => result.ShouldHaveResourceNotFoundError());
 
             // Assert
-            ex.ShouldNotBeNull();
-            ex.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -124,6 +124,63 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
         #endregion ShouldBeCreatedBy(long createdById)
 
+        #region ShouldBeCreatedBy(IEntity createdBy)
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.CreatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.CreatedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeCreatedBy(createdBy: expected));
+        }
+
+        #endregion ShouldBeCreatedBy(long createdById)
+
         #region ShouldHaveBasicError
 
         [Fact]
@@ -335,6 +392,40 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldHaveErrorsFor
+
+        #region ShouldHaveResultObject
+
+        [Fact]
+        public void ShouldHaveResultObject_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<object> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObject());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObject_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<object>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObject());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObject_When_ResultObject_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldHaveResultObject());
+        }
+
+        #endregion ShouldHaveResultObject
 
         #region ShouldHaveResourceNotFoundError
 

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -1,4 +1,3 @@
-using AndcultureCode.CSharp.Core.Models;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -7,8 +6,9 @@ using AndcultureCode.CSharp.Testing.Constants;
 using System.Collections.Generic;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Testing.Factories;
-using System;
 using AndcultureCode.CSharp.Core.Models.Errors;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Models.Stubs;
 
 namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 {
@@ -23,6 +23,107 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
         #endregion Setup
 
+        #region ShouldBeCreated
+
+        [Fact]
+        public void ShouldBeCreated_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreated());
+        }
+
+        [Fact]
+        public void ShouldBeCreated_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreated());
+        }
+
+        [Fact]
+        public void ShouldBeCreated_When_CreatedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreated());
+        }
+
+        [Fact]
+        public void ShouldBeCreated_When_CreatedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeCreated());
+        }
+
+        #endregion ShouldBeCreated
+
+        #region ShouldBeCreatedBy(long createdById)
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_ResultObject_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.ResultObject = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var createdById = Random.Long(min: 1, max: 100);
+            var unexpected = createdById + 1;
+            var result = BuildResult<UserStub>((e) => e.CreatedById = createdById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldBeCreatedBy(createdById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.CreatedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeCreatedBy(createdById: expected));
+        }
+
+        #endregion ShouldBeCreatedBy(long createdById)
+
         #region ShouldHaveBasicError
 
         [Fact]
@@ -32,10 +133,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() =>
-            {
-                result.ShouldHaveBasicError();
-            });
+            var ex = Record.Exception(() => result.ShouldHaveBasicError());
 
             // Assert
             ex.ShouldNotBeNull();
@@ -49,10 +147,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = new List<IError>());
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveBasicError();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveBasicError());
         }
 
         [Fact]
@@ -65,10 +160,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveBasicError();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveBasicError());
         }
 
         [Fact]
@@ -81,10 +173,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.NotThrow(() =>
-            {
-                result.ShouldHaveBasicError();
-            });
+            Should.NotThrow(() => result.ShouldHaveBasicError());
         }
 
         #endregion ShouldHaveBasicError
@@ -115,10 +204,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = new List<IError>());
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveErrors());
         }
 
         [Fact]
@@ -131,10 +217,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.NotThrow(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            Should.NotThrow(() => result.ShouldHaveErrors());
         }
 
         #endregion ShouldHaveErrors<T>
@@ -148,10 +231,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<bool>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            var ex = Record.Exception(() => result.ShouldHaveErrors());
 
             // Assert
             ex.ShouldNotBeNull();
@@ -165,10 +245,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<bool>((e) => e.Errors = new List<IError>());
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveErrors());
         }
 
         [Fact]
@@ -185,10 +262,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             );
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveErrors());
         }
 
         [Fact]
@@ -201,10 +275,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.NotThrow(() =>
-            {
-                result.ShouldHaveErrors();
-            });
+            Should.NotThrow(() => result.ShouldHaveErrors());
         }
 
         #endregion ShouldHaveErrors<bool>
@@ -218,10 +289,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() =>
-            {
-                result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);
-            });
+            var ex = Record.Exception(() => result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY));
 
             // Assert
             ex.ShouldNotBeNull();
@@ -235,10 +303,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = new List<IError>());
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY);
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveErrorsFor(ErrorConstants.BASIC_ERROR_KEY));
         }
 
         [Fact]
@@ -252,10 +317,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveErrorsFor($"not-{error.Key}");
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveErrorsFor($"not-{error.Key}"));
         }
 
         [Fact]
@@ -268,14 +330,8 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
                 error
             });
 
-            // Act
-            var ex = Record.Exception(() =>
-            {
-                result.ShouldHaveErrorsFor(error.Key);
-            });
-
-            // Assert
-            ex.ShouldBeNull();
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldHaveErrorsFor(error.Key));
         }
 
         #endregion ShouldHaveErrorsFor
@@ -289,10 +345,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = null);
 
             // Act
-            var ex = Record.Exception(() =>
-            {
-                result.ShouldHaveResourceNotFoundError();
-            });
+            var ex = Record.Exception(() => result.ShouldHaveResourceNotFoundError());
 
             // Assert
             ex.ShouldNotBeNull();
@@ -306,10 +359,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             var result = BuildResult<object>((e) => e.Errors = new List<IError>());
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveResourceNotFoundError();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResourceNotFoundError());
         }
 
         [Fact]
@@ -322,10 +372,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.Throw<Exception>(() =>
-            {
-                result.ShouldHaveResourceNotFoundError();
-            });
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResourceNotFoundError());
         }
 
         [Fact]
@@ -338,10 +385,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
             });
 
             // Act & Assert
-            Should.NotThrow(() =>
-            {
-                result.ShouldHaveResourceNotFoundError();
-            });
+            Should.NotThrow(() => result.ShouldHaveResourceNotFoundError());
         }
 
         #endregion ShouldHaveResourceNotFoundError


### PR DESCRIPTION
Resolves #48 IResult Auditable matcher extensions

- Some additional cleanup/organization around the `IResultMatcherExtensions` class and tests
- Added utility matchers `ShouldHaveResultObject` and `ShouldHaveResultObjects` extension methods which wrap access to `IResult.ResultObject` for very common assertions

---

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
