### PR TITLE
IAuditable matcher extensions

### DIFF
--- a/src/AndcultureCode.CSharp.Testing/Constants/ErrorConstants.cs
+++ b/src/AndcultureCode.CSharp.Testing/Constants/ErrorConstants.cs
@@ -1,13 +1,39 @@
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
 using AndcultureCode.CSharp.Core.Models.Errors;
 
 namespace AndcultureCode.CSharp.Testing.Constants
 {
+    /// <summary>
+    /// Holds common error keys, messages, Error object configurations, etc.
+    /// </summary>
     public class ErrorConstants
     {
+        /// <summary>
+        /// Generic error key for testing
+        /// </summary>
         public const string BASIC_ERROR_KEY = "TESTERRORKEY";
+
+        /// <summary>
+        /// Generic error message for testing
+        /// </summary>
         public const string BASIC_ERROR_MESSAGE = "TEST ERROR MESSAGE";
+
+        /// <summary>
+        /// Detailed output message to display when expecting errors on a result that has a null `Errors` property
+        /// </summary>
+        public static string ERROR_ERRORS_LIST_IS_NULL_MESSAGE = $"Expected {typeof(IResult<>).Name} to have errors, but instead Errors is 'null'";
+
+        /// <summary>
+        /// Friendlier output message to display when expected entity is not valid for test assertion to continue
+        /// </summary>
+        public static string ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE = $"Expected {nameof(IEntity)} should have a value, but instead is 'null'. Verify your test arrangement is correct.";
+
         public const string JOB_CANCELED_MESSAGE = "The operation was canceled.";
 
+        /// <summary>
+        /// Generic Error object for testing
+        /// </summary>
         public static Error BasicError => new Error { Key = BASIC_ERROR_KEY, Message = BASIC_ERROR_MESSAGE };
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/ICreatableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/ICreatableMatcherExtensions.cs
@@ -44,5 +44,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             entity.ShouldNotBeNull();
             entity.ShouldBeCreatedBy(createdBy.Id);
         }
+
+        /// <summary>
+        /// Assert that the `ICreatable` has a null `CreatedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldNotBeCreated<TCreatable>(this TCreatable entity)
+            where TCreatable : ICreatable
+        {
+            entity.ShouldNotBeNull();
+            entity.CreatedOn.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `ICreatable` does not match the provided `CreatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="createdById">Unexpected id of the record's creator</param>
+        public static void ShouldNotBeCreatedBy<TCreatable>(this TCreatable entity, long createdById)
+            where TCreatable : ICreatable
+        {
+            entity.ShouldNotBeNull();
+            entity.CreatedById.ShouldNotBe(createdById);
+        }
+
+        /// <summary>
+        /// Assert that the `ICreatable` does not match the provided `CreatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="createdBy">Unexpected record's creator</param>
+        public static void ShouldNotBeCreatedBy<TCreatable>(this TCreatable entity, IEntity createdBy)
+            where TCreatable : ICreatable
+        {
+            createdBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldNotBeCreatedBy(createdBy.Id);
+        }
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/ICreatableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/ICreatableMatcherExtensions.cs
@@ -1,0 +1,48 @@
+using Shouldly;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Constants;
+
+namespace AndcultureCode.CSharp.Testing.Extensions
+{
+    /// <summary>
+    /// Extension methods for asserting expected states of the `ICreatable` interface
+    /// </summary>
+    public static class ICreatableMatcherExtensions
+    {
+        /// <summary>
+        /// Assert that the `ICreatable` has a `CreatedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldBeCreated<TCreatable>(this TCreatable entity)
+            where TCreatable : ICreatable
+        {
+            entity.ShouldNotBeNull();
+            entity.CreatedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `ICreatable` has the expected `CreatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="createdById">Expected id of the record's creator</param>
+        public static void ShouldBeCreatedBy<TCreatable>(this TCreatable entity, long createdById)
+            where TCreatable : ICreatable
+        {
+            entity.ShouldNotBeNull();
+            entity.CreatedById.ShouldBe(createdById);
+        }
+
+        /// <summary>
+        /// Assert that the `ICreatable` has the expected `CreatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="createdBy">Expected record's creator</param>
+        public static void ShouldBeCreatedBy<TCreatable>(this TCreatable entity, IEntity createdBy)
+            where TCreatable : ICreatable
+        {
+            createdBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldBeCreatedBy(createdBy.Id);
+        }
+    }
+}

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IDeletableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IDeletableMatcherExtensions.cs
@@ -1,0 +1,48 @@
+using Shouldly;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Constants;
+
+namespace AndcultureCode.CSharp.Testing.Extensions
+{
+    /// <summary>
+    /// Extension methods for asserting expected states of the `IDeletable` interface
+    /// </summary>
+    public static class IDeletableMatcherExtensions
+    {
+        /// <summary>
+        /// Assert that the `IDeletable` has a `DeletedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldBeDeleted<TDeletable>(this TDeletable entity)
+            where TDeletable : IDeletable
+        {
+            entity.ShouldNotBeNull();
+            entity.DeletedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `IDeletable` has the expected `DeletedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="deletedById">Expected id of the record's deletor</param>
+        public static void ShouldBeDeletedBy<TDeletable>(this TDeletable entity, long deletedById)
+            where TDeletable : IDeletable
+        {
+            entity.ShouldNotBeNull();
+            entity.DeletedById.ShouldBe(deletedById);
+        }
+
+        /// <summary>
+        /// Assert that the `IDeletable` has the expected `DeletedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="deletedBy">Expected record's deletor</param>
+        public static void ShouldBeDeletedBy<TDeletable>(this TDeletable entity, IEntity deletedBy)
+            where TDeletable : IDeletable
+        {
+            deletedBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldBeDeletedBy(deletedBy.Id);
+        }
+    }
+}

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IDeletableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IDeletableMatcherExtensions.cs
@@ -44,5 +44,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             entity.ShouldNotBeNull();
             entity.ShouldBeDeletedBy(deletedBy.Id);
         }
+
+        /// <summary>
+        /// Assert that the `IDeletable` has a null `DeletedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldNotBeDeleted<TDeletable>(this TDeletable entity)
+            where TDeletable : IDeletable
+        {
+            entity.ShouldNotBeNull();
+            entity.DeletedOn.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `IDeletable` does not match the provided `DeletedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="deletedById">Unexpected id of the record's deletor</param>
+        public static void ShouldNotBeDeletedBy<TDeletable>(this TDeletable entity, long deletedById)
+            where TDeletable : IDeletable
+        {
+            entity.ShouldNotBeNull();
+            entity.DeletedById.ShouldNotBe(deletedById);
+        }
+
+        /// <summary>
+        /// Assert that the `IDeletable` does not match the provided `DeletedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="deletedBy">Unexpected record's deletor</param>
+        public static void ShouldNotBeDeletedBy<TDeletable>(this TDeletable entity, IEntity deletedBy)
+            where TDeletable : IDeletable
+        {
+            deletedBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldNotBeDeletedBy(deletedBy.Id);
+        }
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -332,7 +332,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         /// </summary>
         /// <param name="result">Result under test</param>
         /// <param name="exactCount">When supplied, asserts that the collection has exactly this number of elements</param>
-        public static void ShouldHaveResultObjects<T>(this IResult<IEnumerable<T>> result, int? exactCount = null)
+        public static void ShouldHaveResultObjects<TResultObjects>(this IResult<TResultObjects> result, int? exactCount = null)
+            where TResultObjects : IEnumerable<object>
         {
             result.ShouldHaveResultObject();
             if (exactCount != null)

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -14,19 +14,6 @@ namespace AndcultureCode.CSharp.Testing.Extensions
     /// </summary>
     public static class IResultMatcherExtensions
     {
-        #region Constants
-
-        /// <summary>
-        /// Detailed output message to display when expecting errors on a result that has a null `Errors` property
-        /// </summary>
-        public static string ERROR_ERRORS_LIST_IS_NULL_MESSAGE = $"Expected {typeof(IResult<>).Name} to have errors, but instead Errors is 'null'";
-
-        /// <summary>
-        /// Friendlier output message to display when expected entity is not valid for test assertion to continue
-        /// </summary>
-        public static string ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE = $"Expected {nameof(IEntity)} should have a value, but instead is 'null'. Verify your test arrangement is correct.";
-
-        #endregion Constants
 
         #region Public Methods
 
@@ -54,7 +41,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeCreated<TCreatable>(this IResult<TCreatable> result) where TCreatable : ICreatable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.CreatedOn.ShouldNotBeNull();
+            result.ResultObject.ShouldBeCreated();
         }
 
         /// <summary>
@@ -66,7 +53,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             where TCreatable : ICreatable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.CreatedById.ShouldBe(createdById);
+            result.ResultObject.ShouldBeCreatedBy(createdById);
         }
 
         /// <summary>
@@ -77,8 +64,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeCreatedBy<TCreatable>(this IResult<TCreatable> result, IEntity createdBy)
             where TCreatable : ICreatable
         {
-            createdBy.ExpectedEntityShouldNotBeNull();
-            result.ShouldBeCreatedBy(createdBy.Id);
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldBeCreatedBy(createdBy);
         }
 
         #endregion IResult<ICreatable> Extensions
@@ -92,7 +79,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeDeleted<TDeletable>(this IResult<TDeletable> result) where TDeletable : IDeletable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.DeletedOn.ShouldNotBeNull();
+            result.ResultObject.ShouldBeDeleted();
         }
 
         /// <summary>
@@ -104,7 +91,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             where TDeletable : IDeletable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.DeletedById.ShouldBe(deletedById);
+            result.ResultObject.ShouldBeDeletedBy(deletedById);
         }
 
         /// <summary>
@@ -115,8 +102,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeDeletedBy<TDeletable>(this IResult<TDeletable> result, IEntity deletedBy)
             where TDeletable : IDeletable
         {
-            deletedBy.ExpectedEntityShouldNotBeNull();
-            result.ShouldBeDeletedBy(deletedBy.Id);
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldBeDeletedBy(deletedBy);
         }
 
         #endregion IResult<IDeletable> Extensions
@@ -130,7 +117,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeUpdated<TUpdatable>(this IResult<TUpdatable> result) where TUpdatable : IUpdatable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.UpdatedOn.ShouldNotBeNull();
+            result.ResultObject.ShouldBeUpdated();
         }
 
         /// <summary>
@@ -142,7 +129,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             where TUpdatable : IUpdatable
         {
             result.ShouldHaveResultObject();
-            result.ResultObject.UpdatedById.ShouldBe(updatedById);
+            result.ResultObject.ShouldBeUpdatedBy(updatedById);
         }
 
         /// <summary>
@@ -153,8 +140,8 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, IEntity updatedBy)
             where TUpdatable : IUpdatable
         {
-            updatedBy.ExpectedEntityShouldNotBeNull();
-            result.ShouldBeUpdatedBy(updatedBy.Id);
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldBeUpdatedBy(updatedBy);
         }
 
         #endregion IResult<IUpdatable> Extensions
@@ -175,7 +162,7 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         public static void ShouldHaveErrors<T>(this IResult<T> result, int? exactCount = null)
         {
             result.ShouldNotBeNull();
-            result.Errors.ShouldNotBeNull(ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            result.Errors.ShouldNotBeNull(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
             result.Errors.Count.ShouldBeGreaterThan(0);
             result.ErrorCount.ShouldBeGreaterThan(0);
             result.HasErrors.ShouldBeTrue();
@@ -284,12 +271,5 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         #endregion IResult<T> Extensions
 
         #endregion Public Methods
-
-        #region Private Methods
-
-        private static void ExpectedEntityShouldNotBeNull(this IEntity entity) =>
-            entity.ShouldNotBeNull(ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
-
-        #endregion Private Methods
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IResultMatcherExtensions.cs
@@ -68,6 +68,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             result.ResultObject.ShouldBeCreatedBy(createdBy);
         }
 
+        /// <summary>
+        /// Assert that the `ResultObject` has a null `CreatedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldNotBeCreated<TCreatable>(this IResult<TCreatable> result)
+            where TCreatable : ICreatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeCreated();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `CreatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="createdById">Unexpected id of the record's creator</param>
+        public static void ShouldNotBeCreatedBy<TCreatable>(this IResult<TCreatable> result, long createdById)
+            where TCreatable : ICreatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeCreatedBy(createdById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `CreatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="createdBy">Unexpected record's creator</param>
+        public static void ShouldNotBeCreatedBy<TCreatable>(this IResult<TCreatable> result, IEntity createdBy)
+            where TCreatable : ICreatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeCreatedBy(createdBy);
+        }
+
         #endregion IResult<ICreatable> Extensions
 
         #region IResult<IDeletable> Extensions
@@ -106,6 +141,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             result.ResultObject.ShouldBeDeletedBy(deletedBy);
         }
 
+        /// <summary>
+        /// Assert that the `ResultObject` has a null `DeletedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldNotBeDeleted<TDeletable>(this IResult<TDeletable> result)
+            where TDeletable : IDeletable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeDeleted();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `DeletedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="deletedById">Unexpected id of the record's deletor</param>
+        public static void ShouldNotBeDeletedBy<TDeletable>(this IResult<TDeletable> result, long deletedById)
+            where TDeletable : IDeletable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeDeletedBy(deletedById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `DeletedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="deletedBy">Unexpected record's deletor</param>
+        public static void ShouldNotBeDeletedBy<TDeletable>(this IResult<TDeletable> result, IEntity deletedBy)
+            where TDeletable : IDeletable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeDeletedBy(deletedBy);
+        }
+
         #endregion IResult<IDeletable> Extensions
 
         #region IResult<IUpdatable> Extensions
@@ -142,6 +212,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
         {
             result.ShouldHaveResultObject();
             result.ResultObject.ShouldBeUpdatedBy(updatedBy);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` has a null `UpdatedOn` value
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        public static void ShouldNotBeUpdated<TUpdatable>(this IResult<TUpdatable> result)
+            where TUpdatable : IUpdatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeUpdated();
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `UpdatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="updatedById">Unexpected id of the record's updater</param>
+        public static void ShouldNotBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, long updatedById)
+            where TUpdatable : IUpdatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeUpdatedBy(updatedById);
+        }
+
+        /// <summary>
+        /// Assert that the `ResultObject` does not match the provided `UpdatedById`
+        /// </summary>
+        /// <param name="result">Result under test</param>
+        /// <param name="updatedBy">Unexpected record's updater</param>
+        public static void ShouldNotBeUpdatedBy<TUpdatable>(this IResult<TUpdatable> result, IEntity updatedBy)
+            where TUpdatable : IUpdatable
+        {
+            result.ShouldHaveResultObject();
+            result.ResultObject.ShouldNotBeUpdatedBy(updatedBy);
         }
 
         #endregion IResult<IUpdatable> Extensions

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IUpdatableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IUpdatableMatcherExtensions.cs
@@ -44,5 +44,41 @@ namespace AndcultureCode.CSharp.Testing.Extensions
             entity.ShouldNotBeNull();
             entity.ShouldBeUpdatedBy(updatedBy.Id);
         }
+
+        /// <summary>
+        /// Assert that the `IUpdatable` has a null `UpdatedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldNotBeUpdated<TUpdatable>(this TUpdatable entity)
+            where TUpdatable : IUpdatable
+        {
+            entity.ShouldNotBeNull();
+            entity.UpdatedOn.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `IUpdatable` does not match the provided `UpdatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="updatedById">Unexpected id of the record's updater</param>
+        public static void ShouldNotBeUpdatedBy<TUpdatable>(this TUpdatable entity, long updatedById)
+            where TUpdatable : IUpdatable
+        {
+            entity.ShouldNotBeNull();
+            entity.UpdatedById.ShouldNotBe(updatedById);
+        }
+
+        /// <summary>
+        /// Assert that the `IUpdatable` does not match the provided `UpdatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="updatedBy">Unexpected record's updater</param>
+        public static void ShouldNotBeUpdatedBy<TUpdatable>(this TUpdatable entity, IEntity updatedBy)
+            where TUpdatable : IUpdatable
+        {
+            updatedBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldNotBeUpdatedBy(updatedBy.Id);
+        }
     }
 }

--- a/src/AndcultureCode.CSharp.Testing/Extensions/IUpdatableMatcherExtensions.cs
+++ b/src/AndcultureCode.CSharp.Testing/Extensions/IUpdatableMatcherExtensions.cs
@@ -1,0 +1,48 @@
+using Shouldly;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Constants;
+
+namespace AndcultureCode.CSharp.Testing.Extensions
+{
+    /// <summary>
+    /// Extension methods for asserting expected states of the `IUpdatable` interface
+    /// </summary>
+    public static class IUpdatableMatcherExtensions
+    {
+        /// <summary>
+        /// Assert that the `IUpdatable` has a `UpdatedOn` value
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        public static void ShouldBeUpdated<TUpdatable>(this TUpdatable entity)
+            where TUpdatable : IUpdatable
+        {
+            entity.ShouldNotBeNull();
+            entity.UpdatedOn.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Assert that the `IUpdatable` has the expected `UpdatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="updatedById">Expected id of the record's deletor</param>
+        public static void ShouldBeUpdatedBy<TUpdatable>(this TUpdatable entity, long updatedById)
+            where TUpdatable : IUpdatable
+        {
+            entity.ShouldNotBeNull();
+            entity.UpdatedById.ShouldBe(updatedById);
+        }
+
+        /// <summary>
+        /// Assert that the `IUpdatable` has the expected `UpdatedById`
+        /// </summary>
+        /// <param name="entity">Entity under test</param>
+        /// <param name="updatedBy">Expected record's deletor</param>
+        public static void ShouldBeUpdatedBy<TUpdatable>(this TUpdatable entity, IEntity updatedBy)
+            where TUpdatable : IUpdatable
+        {
+            updatedBy.ShouldNotBeNull(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            entity.ShouldNotBeNull();
+            entity.ShouldBeUpdatedBy(updatedBy.Id);
+        }
+    }
+}

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
@@ -160,5 +160,147 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldBeCreatedBy(IEntity createdBy)
+
+        #region ShouldNotBeCreated
+
+        [Fact]
+        public void ShouldNotBeCreated_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreated());
+        }
+
+        [Fact]
+        public void ShouldNotBeCreated_When_CreatedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreated());
+        }
+
+        [Fact]
+        public void ShouldNotBeCreated_When_CreatedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.CreatedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeCreated());
+        }
+
+        #endregion ShouldNotBeCreated
+
+        #region ShouldNotBeCreatedBy(long createdById)
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.CreatedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreatedBy(createdById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var createdById = Random.Long(min: 1, max: 100);
+            var unexpected = createdById + 1;
+            var entity = Build<UserStub>((e) => e.CreatedById = createdById);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeCreatedBy(createdById: unexpected));
+        }
+
+        #endregion ShouldNotBeCreatedBy(long createdById)
+
+        #region ShouldNotBeCreatedBy(IEntity createdBy)
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldNotBeCreatedBy(createdBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreatedBy(createdBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.CreatedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreatedBy(createdBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.CreatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeCreatedBy(createdBy: unexpected));
+        }
+
+        #endregion ShouldNotBeCreatedBy(IEntity createdBy)
     }
 }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
@@ -45,10 +45,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldBeCreated_When_CreatedOn_HasValue_Passes_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.NotThrow(() => result.ShouldBeCreated());
+            Should.NotThrow(() => entity.ShouldBeCreated());
         }
 
         #endregion ShouldBeCreated
@@ -177,10 +177,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldNotBeCreated_When_CreatedOn_HasValue_Fails_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreated());
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeCreated());
         }
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/ICreatableMatcherExtensionsTest.cs
@@ -1,0 +1,164 @@
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Constants;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Models.Stubs;
+
+namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
+{
+    public class ICreatableMatcherExtensionsTest : ProjectUnitTest
+    {
+        #region Setup
+
+        public ICreatableMatcherExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        #endregion Setup
+
+        #region ShouldBeCreated
+
+        [Fact]
+        public void ShouldBeCreated_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreated());
+        }
+
+        [Fact]
+        public void ShouldBeCreated_When_CreatedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.CreatedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreated());
+        }
+
+        [Fact]
+        public void ShouldBeCreated_When_CreatedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeCreated());
+        }
+
+        #endregion ShouldBeCreated
+
+        #region ShouldBeCreatedBy(long createdById)
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var createdById = Random.Long(min: 1, max: 100);
+            var unexpected = createdById + 1;
+            var entity = Build<UserStub>((e) => e.CreatedById = createdById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedById_When_CreatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.CreatedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeCreatedBy(createdById: expected));
+        }
+
+        #endregion ShouldBeCreatedBy(long createdById)
+
+        #region ShouldBeCreatedBy(IEntity createdBy)
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldBeCreatedBy(createdBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            ICreatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.CreatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeCreatedBy_CreatedBy_When_CreatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.CreatedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeCreatedBy(createdBy: expected));
+        }
+
+        #endregion ShouldBeCreatedBy(IEntity createdBy)
+    }
+}

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
@@ -1,0 +1,164 @@
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Constants;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Models.Stubs;
+
+namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
+{
+    public class IDeletableMatcherExtensionsTest : ProjectUnitTest
+    {
+        #region Setup
+
+        public IDeletableMatcherExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        #endregion Setup
+
+        #region ShouldBeDeleted
+
+        [Fact]
+        public void ShouldBeDeleted_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldBeDeleted_When_DeletedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.DeletedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldBeDeleted_When_DeletedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeDeleted());
+        }
+
+        #endregion ShouldBeDeleted
+
+        #region ShouldBeDeletedBy(long deletedById)
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var deletedById = Random.Long(min: 1, max: 100);
+            var unexpected = deletedById + 1;
+            var entity = Build<UserStub>((e) => e.DeletedById = deletedById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedById_When_DeletedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.DeletedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeDeletedBy(deletedById: expected));
+        }
+
+        #endregion ShouldBeDeletedBy(long deletedById)
+
+        #region ShouldBeDeletedBy(IEntity deletedBy)
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldBeDeletedBy(deletedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.DeletedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeDeletedBy_DeletedBy_When_DeletedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.DeletedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeDeletedBy(deletedBy: expected));
+        }
+
+        #endregion ShouldBeDeletedBy(IEntity deletedBy)
+    }
+}

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
@@ -45,10 +45,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldBeDeleted_When_DeletedOn_HasValue_Passes_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.NotThrow(() => result.ShouldBeDeleted());
+            Should.NotThrow(() => entity.ShouldBeDeleted());
         }
 
         #endregion ShouldBeDeleted
@@ -177,10 +177,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldNotBeDeleted_When_DeletedOn_HasValue_Fails_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeleted());
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeleted());
         }
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IDeletableMatcherExtensionsTest.cs
@@ -160,5 +160,147 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldBeDeletedBy(IEntity deletedBy)
+
+        #region ShouldNotBeDeleted
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_DeletedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_DeletedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.DeletedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeDeleted());
+        }
+
+        #endregion ShouldNotBeDeleted
+
+        #region ShouldNotBeDeletedBy(long deletedById)
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.DeletedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeletedBy(deletedById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var deletedById = Random.Long(min: 1, max: 100);
+            var unexpected = deletedById + 1;
+            var entity = Build<UserStub>((e) => e.DeletedById = deletedById);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeDeletedBy(deletedById: unexpected));
+        }
+
+        #endregion ShouldNotBeDeletedBy(long deletedById)
+
+        #region ShouldNotBeDeletedBy(IEntity deletedBy)
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldNotBeDeletedBy(deletedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IDeletable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeletedBy(deletedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.DeletedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeDeletedBy(deletedBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.DeletedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeDeletedBy(deletedBy: unexpected));
+        }
+
+        #endregion ShouldNotBeDeletedBy(IEntity deletedBy)
     }
 }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -916,5 +916,431 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldHaveResourceNotFoundError
+
+        #region ShouldNotBeCreated
+
+        [Fact]
+        public void ShouldNotBeCreated_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreated());
+        }
+
+        [Fact]
+        public void ShouldNotBeCreated_When_CreatedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreated());
+        }
+
+        [Fact]
+        public void ShouldNotBeCreated_When_CreatedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeCreated());
+        }
+
+        #endregion ShouldNotBeCreated
+
+        #region ShouldNotBeCreatedBy(long createdById)
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.CreatedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreatedBy(createdById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeCreatedBy(createdById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedById_When_CreatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var createdById = Random.Long(min: 1, max: 100);
+            var unexpected = createdById + 1;
+            var result = BuildResult<UserStub>((e) => e.CreatedById = createdById);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeCreatedBy(createdById: unexpected));
+        }
+
+        #endregion ShouldNotBeCreatedBy(long createdById)
+
+        #region ShouldNotBeCreatedBy(IEntity createdBy)
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldNotBeCreatedBy(createdBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<ICreatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreatedBy(createdBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.CreatedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeCreatedBy(createdBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.CreatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeCreatedBy(createdBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeCreatedBy_CreatedBy_When_CreatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.CreatedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.CreatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeCreatedBy(createdBy: unexpected));
+        }
+
+        #endregion ShouldNotBeCreatedBy(IEntity createdBy)
+
+        #region ShouldNotBeDeleted
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_DeletedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeleted());
+        }
+
+        [Fact]
+        public void ShouldNotBeDeleted_When_DeletedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeDeleted());
+        }
+
+        #endregion ShouldNotBeDeleted
+
+        #region ShouldNotBeDeletedBy(long deletedById)
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.DeletedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeletedBy(deletedById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeDeletedBy(deletedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedById_When_DeletedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var deletedById = Random.Long(min: 1, max: 100);
+            var unexpected = deletedById + 1;
+            var result = BuildResult<UserStub>((e) => e.DeletedById = deletedById);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeDeletedBy(deletedById: unexpected));
+        }
+
+        #endregion ShouldNotBeDeletedBy(long deletedById)
+
+        #region ShouldNotBeDeletedBy(IEntity deletedBy)
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldNotBeDeletedBy(deletedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IDeletable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeletedBy(deletedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.DeletedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeDeletedBy(deletedBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.DeletedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeDeletedBy(deletedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeDeletedBy_DeletedBy_When_DeletedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.DeletedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.DeletedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeDeletedBy(deletedBy: unexpected));
+        }
+
+        #endregion ShouldNotBeDeletedBy(IEntity deletedBy)
+
+        #region ShouldNotBeUpdated
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_UpdatedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_UpdatedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeUpdated());
+        }
+
+        #endregion ShouldNotBeUpdated
+
+        #region ShouldNotBeUpdatedBy(long updatedById)
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdatedBy(updatedById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var updatedById = Random.Long(min: 1, max: 100);
+            var unexpected = updatedById + 1;
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = updatedById);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeUpdatedBy(updatedById: unexpected));
+        }
+
+        #endregion ShouldNotBeUpdatedBy(long updatedById)
+
+        #region ShouldNotBeUpdatedBy(IEntity updatedBy)
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => result.ShouldNotBeUpdatedBy(updatedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_Result_Null_Fails_Assertion()
+        {
+            // Arrange
+            IResult<IUpdatable> result = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdatedBy(updatedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdatedBy(updatedBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long(min: 1, max: 100));
+            var result = BuildResult<UserStub>((e) => e.UpdatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldNotBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        #endregion ShouldNotBeUpdatedBy(IEntity updatedBy)
     }
 }

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -809,10 +809,32 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         [Fact]
-        public void ShouldHaveResultObjects_When_ResultObject_Empty_Fails_Assertion()
+        public void ShouldHaveResultObjects_When_ResultObject_Empty_Enumerable_Fails_Assertion()
         {
             // Arrange
-            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = new List<UserStub>());
+            var result = BuildResult<IEnumerable<UserStub>>((e) => e.ResultObject = Enumerable.Empty<UserStub>());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_Empty_Queryable_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<IQueryable<UserStub>>(
+                (e) => e.ResultObject = Enumerable.Empty<UserStub>().AsQueryable()
+            );
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());
+        }
+
+        [Fact]
+        public void ShouldHaveResultObjects_When_ResultObject_Empty_List_Fails_Assertion()
+        {
+            // Arrange
+            var result = BuildResult<List<UserStub>>((e) => e.ResultObject = new List<UserStub>());
 
             // Act & Assert
             Should.Throw<ShouldAssertException>(() => result.ShouldHaveResultObjects());

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IResultMatcherExtensionsTest.cs
@@ -138,7 +138,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -482,7 +482,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -553,7 +553,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -610,7 +610,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -651,7 +651,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -709,7 +709,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]
@@ -876,7 +876,7 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
 
             // Assert
             exception.ShouldNotBeNull();
-            exception.Message.ShouldContain(IResultMatcherExtensions.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
+            exception.Message.ShouldContain(ErrorConstants.ERROR_ERRORS_LIST_IS_NULL_MESSAGE);
         }
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
@@ -45,10 +45,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldBeUpdated_When_UpdatedOn_HasValue_Passes_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.NotThrow(() => result.ShouldBeUpdated());
+            Should.NotThrow(() => entity.ShouldBeUpdated());
         }
 
         #endregion ShouldBeUpdated
@@ -177,10 +177,10 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         public void ShouldNotBeUpdated_When_UpdatedOn_HasValue_Fails_Assertion()
         {
             // Arrange
-            var result = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+            var entity = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
 
             // Act & Assert
-            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdated());
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdated());
         }
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
@@ -1,0 +1,164 @@
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Testing.Constants;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+using AndcultureCode.CSharp.Testing.Models.Stubs;
+
+namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
+{
+    public class IUpdatableMatcherExtensionsTest : ProjectUnitTest
+    {
+        #region Setup
+
+        public IUpdatableMatcherExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+
+        }
+
+        #endregion Setup
+
+        #region ShouldBeUpdated
+
+        [Fact]
+        public void ShouldBeUpdated_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldBeUpdated_When_UpdatedOn_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.UpdatedOn = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldBeUpdated_When_UpdatedOn_HasValue_Passes_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.NotThrow(() => result.ShouldBeUpdated());
+        }
+
+        #endregion ShouldBeUpdated
+
+        #region ShouldBeUpdatedBy(long updatedById)
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var updatedById = Random.Long(min: 1, max: 100);
+            var unexpected = updatedById + 1;
+            var entity = Build<UserStub>((e) => e.UpdatedById = updatedById);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedById: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedById_When_UpdatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.UpdatedById = expected);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeUpdatedBy(updatedById: expected));
+        }
+
+        #endregion ShouldBeUpdatedBy(long updatedById)
+
+        #region ShouldBeUpdatedBy(IEntity updatedBy)
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldBeUpdatedBy(updatedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Null_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Does_Not_Match_Fails_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.UpdatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldBeUpdatedBy_UpdatedBy_When_UpdatedById_Matches_Passes_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.UpdatedById = expected.Id);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldBeUpdatedBy(updatedBy: expected));
+        }
+
+        #endregion ShouldBeUpdatedBy(IEntity updatedBy)
+    }
+}

--- a/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Testing.Tests/Tests/Unit/Extensions/IUpdatableMatcherExtensionsTest.cs
@@ -160,5 +160,147 @@ namespace AndcultureCode.CSharp.Testing.Tests.Unit.Extensions
         }
 
         #endregion ShouldBeUpdatedBy(IEntity updatedBy)
+
+        #region ShouldNotBeUpdated
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_UpdatedOn_HasValue_Fails_Assertion()
+        {
+            // Arrange
+            var result = Build<UserStub>((e) => e.UpdatedOn = Faker.Date.RecentOffset());
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => result.ShouldNotBeUpdated());
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdated_When_UpdatedOn_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.UpdatedOn = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeUpdated());
+        }
+
+        #endregion ShouldNotBeUpdated
+
+        #region ShouldNotBeUpdatedBy(long updatedById)
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Random.Long();
+            var entity = Build<UserStub>((e) => e.UpdatedById = expected);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdatedBy(updatedById: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeUpdatedBy(updatedById: Random.Long()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedById_When_UpdatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var updatedById = Random.Long(min: 1, max: 100);
+            var unexpected = updatedById + 1;
+            var entity = Build<UserStub>((e) => e.UpdatedById = updatedById);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeUpdatedBy(updatedById: unexpected));
+        }
+
+        #endregion ShouldNotBeUpdatedBy(long updatedById)
+
+        #region ShouldNotBeUpdatedBy(IEntity updatedBy)
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_Expected_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            var entity = Build<UserStub>();
+
+            // Act
+            var exception = Record.Exception(() => entity.ShouldNotBeUpdatedBy(updatedBy: (IEntity)null));
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain(ErrorConstants.ERROR_EXPECTED_ENTITY_IS_NULL_MESSAGE);
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_Entity_Null_Fails_Assertion()
+        {
+            // Arrange
+            IUpdatable entity = null;
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdatedBy(updatedBy: Build<UserStub>()));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Matches_Fails_Assertion()
+        {
+            // Arrange
+            var expected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.UpdatedById = expected.Id);
+
+            // Act & Assert
+            Should.Throw<ShouldAssertException>(() => entity.ShouldNotBeUpdatedBy(updatedBy: expected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Null_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long());
+            var entity = Build<UserStub>((e) => e.UpdatedById = null);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        [Fact]
+        public void ShouldNotBeUpdatedBy_UpdatedBy_When_UpdatedById_Does_Not_Match_Passes_Assertion()
+        {
+            // Arrange
+            var unexpected = Build<UserStub>((e) => e.UpdatedById = Random.Long(min: 1, max: 100));
+            var entity = Build<UserStub>((e) => e.UpdatedById = unexpected.Id + 1);
+
+            // Act & Assert
+            Should.NotThrow(() => entity.ShouldNotBeUpdatedBy(updatedBy: unexpected));
+        }
+
+        #endregion ShouldNotBeUpdatedBy(IEntity updatedBy)
     }
 }


### PR DESCRIPTION
Fixes #54 Bug: Update function signature for ShouldHaveResultObjects 
Resolves #55 IAuditable matchers

Additionally added inverse matchers for the recently implemented `IResult<IAuditable>` methods, ie `ShouldNotBeCreated`, `ShouldNotBeCreatedBy`, etc.

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [-] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
